### PR TITLE
OLH-1619: Don't run the post-merge tests in subfolder

### DIFF
--- a/.github/workflows/sam-app-post-merge-actions.yaml
+++ b/.github/workflows/sam-app-post-merge-actions.yaml
@@ -24,9 +24,8 @@ jobs:
           node-version-file: ".nvmrc"
       - name: Install ESbuild
         run: npm install -g esbuild@0.15.12
-      - name: Test account-management-api
+      - name: Run the tests
         run: npm ci && npm test
-        working-directory: ./account-management-api
       - name: Set up Python 3.9
         uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # pin@v4
         with:


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

Don't run the post-merge tests in subfolder.

### Why did it change

We missed this in https://github.com/govuk-one-login/account-management-stubs/pull/30

## Checklists

<!-- Merging this PR deploys the stubs. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

