### PR TITLE
OLH-1661 - Add stub for the create MFA Method endpoint

### DIFF
--- a/src/method-management/method-management.ts
+++ b/src/method-management/method-management.ts
@@ -1,6 +1,6 @@
 import { APIGatewayProxyEvent } from "aws-lambda";
+import assert from "node:assert/strict";
 import { components } from "./models/schema";
-import assert from 'node:assert/strict'
 
 type MfaMethod = components["schemas"]["MfaMethod"];
 
@@ -26,18 +26,29 @@ export const userInfoHandler = async (): Promise<Response> => {
   };
 };
 
-export const createMfaMethodHandler = async (event: APIGatewayProxyEvent): Promise<Response> => {
-  const { email, otp, credential, mfaMethod: {priorityIdentifier, mfaMethodType}} = JSON.parse(event.body || '{}');
+export const createMfaMethodHandler = async (
+  event: APIGatewayProxyEvent
+): Promise<Response> => {
+  const {
+    email,
+    otp,
+    credential,
+    mfaMethod: { priorityIdentifier, mfaMethodType },
+  } = JSON.parse(event.body || "{}");
   try {
-    assert(email, 'no email provided')
-    assert(otp, 'no otp provided')
-    assert(credential, 'no credential provided')
-    assert.match(priorityIdentifier, /^(PRIMARY|SECONDARY)$/, 'invalid priorityIdentifier')
-    assert.match(mfaMethodType, /^(AUTH_APP|SMS)$/, 'invalid mfaMethodType')
-  } catch(e) {
+    assert(email, "no email provided");
+    assert(otp, "no otp provided");
+    assert(credential, "no credential provided");
+    assert.match(
+      priorityIdentifier,
+      /^(PRIMARY|SECONDARY)$/,
+      "invalid priorityIdentifier"
+    );
+    assert.match(mfaMethodType, /^(AUTH_APP|SMS)$/, "invalid mfaMethodType");
+  } catch (e) {
     return {
       statusCode: 400,
-      body: JSON.stringify({error: (e as Error).message}),
+      body: JSON.stringify({ error: (e as Error).message }),
     };
   }
 

--- a/src/method-management/method-management.ts
+++ b/src/method-management/method-management.ts
@@ -1,4 +1,6 @@
+import { APIGatewayProxyEvent } from "aws-lambda";
 import { components } from "./models/schema";
+import assert from 'node:assert/strict'
 
 type MfaMethod = components["schemas"]["MfaMethod"];
 
@@ -24,7 +26,21 @@ export const userInfoHandler = async (): Promise<Response> => {
   };
 };
 
-export const createMfaMethodHandler = async (): Promise<Response> => {
+export const createMfaMethodHandler = async (event: APIGatewayProxyEvent): Promise<Response> => {
+  const { email, otp, credential, mfaMethod: {priorityIdentifier, mfaMethodType}} = JSON.parse(event.body || '{}');
+  try {
+    assert(email, 'no email provided')
+    assert(otp, 'no otp provided')
+    assert(credential, 'no credential provided')
+    assert.match(priorityIdentifier, /^(PRIMARY|SECONDARY)$/, 'invalid priorityIdentifier')
+    assert.match(mfaMethodType, /^(AUTH_APP|SMS)$/, 'invalid mfaMethodType')
+  } catch(e) {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({error: (e as Error).message}),
+    };
+  }
+
   return {
     statusCode: 200,
     body: JSON.stringify({}),

--- a/src/method-management/method-management.ts
+++ b/src/method-management/method-management.ts
@@ -33,7 +33,10 @@ export const createMfaMethodHandler = async (
     email,
     otp,
     credential,
-    mfaMethod: { priorityIdentifier = undefined, mfaMethodType = undefined} = {},
+    mfaMethod: {
+      priorityIdentifier = undefined,
+      mfaMethodType = undefined,
+    } = {},
   } = JSON.parse(event.body || "{}");
   try {
     assert(email, "no email provided");

--- a/src/method-management/method-management.ts
+++ b/src/method-management/method-management.ts
@@ -41,4 +41,6 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<Response> =>
   if (event.path.endsWith('/mfa-methods')) {
     return createMfaMethodHandler();
   }
+
+  throw new Error(`Unknown path: ${event.path}`);
 }

--- a/src/method-management/method-management.ts
+++ b/src/method-management/method-management.ts
@@ -33,7 +33,7 @@ export const createMfaMethodHandler = async (
     email,
     otp,
     credential,
-    mfaMethod: { priorityIdentifier, mfaMethodType },
+    mfaMethod: { priorityIdentifier = undefined, mfaMethodType = undefined} = {},
   } = JSON.parse(event.body || "{}");
   try {
     assert(email, "no email provided");

--- a/src/method-management/method-management.ts
+++ b/src/method-management/method-management.ts
@@ -1,4 +1,3 @@
-import { APIGatewayProxyEvent } from "aws-lambda/trigger/api-gateway-proxy";
 import { components } from "./models/schema";
 
 type MfaMethod = components["schemas"]["MfaMethod"];
@@ -8,7 +7,7 @@ export interface Response {
   body: string;
 }
 
-const userInfoHandler = async (): Promise<Response> => {
+export const userInfoHandler = async (): Promise<Response> => {
   const response: MfaMethod[] = [
     {
       mfaIdentifier: 1,
@@ -25,22 +24,9 @@ const userInfoHandler = async (): Promise<Response> => {
   };
 };
 
-const createMfaMethodHandler = async (): Promise<Response> => {
-
+export const createMfaMethodHandler = async (): Promise<Response> => {
   return {
     statusCode: 200,
-    body: JSON.stringify({})
-  }
-}
-
-export const handler = async (event: APIGatewayProxyEvent): Promise<Response> => {
-  if (event.path.endsWith('/retrieve')) {
-    return userInfoHandler();
-  }
-
-  if (event.path.endsWith('/mfa-methods')) {
-    return createMfaMethodHandler();
-  }
-
-  throw new Error(`Unknown path: ${event.path}`);
-}
+    body: JSON.stringify({}),
+  };
+};

--- a/src/method-management/method-management.ts
+++ b/src/method-management/method-management.ts
@@ -1,3 +1,4 @@
+import { APIGatewayProxyEvent } from "aws-lambda/trigger/api-gateway-proxy";
 import { components } from "./models/schema";
 
 type MfaMethod = components["schemas"]["MfaMethod"];
@@ -7,7 +8,7 @@ export interface Response {
   body: string;
 }
 
-export const handler = async (): Promise<Response> => {
+const userInfoHandler = async (): Promise<Response> => {
   const response: MfaMethod[] = [
     {
       mfaIdentifier: 1,
@@ -23,3 +24,21 @@ export const handler = async (): Promise<Response> => {
     body: JSON.stringify(response),
   };
 };
+
+const createMfaMethodHandler = async (): Promise<Response> => {
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify({})
+  }
+}
+
+export const handler = async (event: APIGatewayProxyEvent): Promise<Response> => {
+  if (event.path.endsWith('/retrieve')) {
+    return userInfoHandler();
+  }
+
+  if (event.path.endsWith('/mfa-methods')) {
+    return createMfaMethodHandler();
+  }
+}

--- a/src/tests/method-management/method-management.test.ts
+++ b/src/tests/method-management/method-management.test.ts
@@ -1,4 +1,5 @@
 import "aws-sdk-client-mock-jest";
+import { APIGatewayProxyEvent } from "aws-lambda";
 import { components } from "../../method-management/models/schema";
 import { handler, Response } from "../../method-management/method-management";
 
@@ -7,7 +8,9 @@ type MfaMethod = components["schemas"]["MfaMethod"];
 describe("MFA Management API Mock", () => {
   test("Registered user with a single MFA of type SMS", async () => {
     // Act
-    const result: Response = await handler();
+    const result: Response = await handler({
+      path: "/retrieve",
+    } as APIGatewayProxyEvent);
 
     // Assert
     expect(result).toBeDefined();

--- a/src/tests/method-management/method-management.test.ts
+++ b/src/tests/method-management/method-management.test.ts
@@ -1,16 +1,16 @@
 import "aws-sdk-client-mock-jest";
-import { APIGatewayProxyEvent } from "aws-lambda";
 import { components } from "../../method-management/models/schema";
-import { handler, Response } from "../../method-management/method-management";
+import {
+  userInfoHandler,
+  Response,
+} from "../../method-management/method-management";
 
 type MfaMethod = components["schemas"]["MfaMethod"];
 
 describe("MFA Management API Mock", () => {
   test("Registered user with a single MFA of type SMS", async () => {
     // Act
-    const result: Response = await handler({
-      path: "/retrieve",
-    } as APIGatewayProxyEvent);
+    const result: Response = await userInfoHandler();
 
     // Assert
     expect(result).toBeDefined();

--- a/template.yaml
+++ b/template.yaml
@@ -894,7 +894,7 @@ Resources:
       FunctionName: !Sub ${Environment}-${AWS::StackName}-method-management-v1
       Architectures: ["arm64"]
       CodeUri: src/method-management
-      Handler: method-management.handler
+      Handler: method-management.userInfoHandler
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
       MemorySize: 128
@@ -907,13 +907,6 @@ Resources:
           Type: Api
           Properties:
             Path: /v1/mfa-methods/retrieve
-            Method: POST
-            RestApiId:
-              Ref: MethodManagementv1StubsRestApi
-        createmethod:
-          Type: Api
-          Properties:
-            Path: /v1/mfa-methods
             Method: POST
             RestApiId:
               Ref: MethodManagementv1StubsRestApi
@@ -958,6 +951,75 @@ Resources:
     UpdateReplacePolicy: Delete
     Properties:
       LogGroupName: !Sub "/aws/lambda/${Environment}-${AWS::StackName}-method-management-v1"
+      RetentionInDays: 30
+      KmsKeyId: !GetAtt LoggingKmsKey.Arn
+
+  MethodManagementCreatev1ApiStubFunction:
+    Type: AWS::Serverless::Function
+    # checkov:skip=CKV_AWS_116
+    DependsOn:
+      - MethodManagementCreatev1ApiStubFunctionLogGroup
+    Properties:
+      FunctionName: !Sub ${Environment}-${AWS::StackName}-method-management-create-v1
+      Architectures: ["arm64"]
+      CodeUri: src/method-management
+      Handler: method-management.createMfaMethodHandler
+      KmsKeyArn: !GetAtt LambdaKMSKey.Arn
+      PackageType: Zip
+      MemorySize: 128
+      ReservedConcurrentExecutions: 30
+      Runtime: nodejs18.x
+      Role: !GetAtt MethodManagementCreatev1ApiStubFunctionRole.Arn
+      Timeout: 5
+      Events:
+        userinfo:
+          Type: Api
+          Properties:
+            Path: /v1/mfa-methods
+            Method: POST
+            RestApiId:
+              Ref: MethodManagementv1StubsRestApi
+      VpcConfig:
+        SubnetIds:
+          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
+          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
+        SecurityGroupIds:
+          - Fn::ImportValue: !Sub ${VpcStackName}-AWSServicesEndpointSecurityGroupId
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        Minify: true
+        Target: "es2020"
+        Sourcemap: true
+        EntryPoints:
+          - method-management.ts
+
+  MethodManagementCreatev1ApiStubFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - "sts:AssumeRole"
+
+  MethodManagementCreatev1ApiStubFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${Environment}-${AWS::StackName}-method-management-create-v1"
       RetentionInDays: 30
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 

--- a/template.yaml
+++ b/template.yaml
@@ -910,6 +910,13 @@ Resources:
             Method: POST
             RestApiId:
               Ref: MethodManagementv1StubsRestApi
+        createmethod:
+          Type: Api
+          Properties:
+            Path: /v1/mfa-methods
+            Method: POST
+            RestApiId:
+              Ref: MethodManagementv1StubsRestApi
       VpcConfig:
         SubnetIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA


### PR DESCRIPTION
## Proposed changes

### What changed

Adds a new POST route to the stub API, to mimic the "create MFA method" endpoint.

### Why did it change

So that we can develop and test the frontend flow.

## Testing

Deploying to dev, and testing the API in the CLI

## How to review

<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->
