### PR TITLE
SW-284: Increase retention of LogGroup to 30 days.

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -337,7 +337,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/apigateway/${OidcStubsRestApi}"
-      RetentionInDays: 1
+      RetentionInDays: 30
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   ######################################
@@ -840,7 +840,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/apigateway/${MethodManagementv1StubsRestApi}"
-      RetentionInDays: 1
+      RetentionInDays: 30
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   ######################################


### PR DESCRIPTION
## Proposed changes

Increase retention of LogGroup to 30 days. Currently any log retention that is set under 30 days will be set to 30 by a Lambda attached to the LZA Lambda run. [SW-284](https://govukverify.atlassian.net/browse/SW-284)

### What changed

- increase RetentionInDays from 1 to 30 days.

### Why did it change

LZA lambda increase log retention to 30 days. If it is 30 days or more it is ignored.

### Related links

[INCIDEN-627](https://govukverify.atlassian.net/browse/INCIDEN-627)

## Checklists

<!-- Merging this PR deploys the stubs. Please answer accurately. -->

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

### Permissions

## Testing

<!-- Provide a summary of any manual testing you've done, for example deploying the branch to dev -->

## How to review

<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->


[SW-284]: https://govukverify.atlassian.net/browse/SW-284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INCIDEN-627]: https://govukverify.atlassian.net/browse/INCIDEN-627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ