### PR TITLE
OLH-1797-add-some-error-responses-to-the-stub

### DIFF
--- a/src/method-management/method-management.ts
+++ b/src/method-management/method-management.ts
@@ -2,7 +2,10 @@ import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import assert from "node:assert/strict";
 import { validateFields } from "../common/validation";
 import { formatResponse } from "../common/response-utils";
-import { getUserIdFromEvent, getUserScenario } from "../scenarios/scenarios";
+import {
+  getUserIdFromEvent,
+  getUserScenario,
+} from "../scenarios/scenarios-utils";
 
 export interface Response {
   statusCode: number;
@@ -12,42 +15,49 @@ export interface Response {
 export const userInfoHandler = async (
   event: APIGatewayProxyEvent
 ): Promise<Response> => {
-  const response = getUserScenario(await getUserIdFromEvent(event), "mfaMethods");
+  const response = getUserScenario(
+    await getUserIdFromEvent(event),
+    "mfaMethods"
+  );
 
   if (response.length === 0) {
     // a user with no MFA factors
-    return formatResponse(404, {})
+    return formatResponse(404, {});
   }
 
   if (response.length > 2) {
     // user with more than 2 methods
-    return formatResponse(422, {})
+    return formatResponse(422, {});
   }
-  
-  const primaryMethodCount = response.filter(m => m.priorityIdentifier === "PRIMARY").length
+
+  const primaryMethodCount = response.filter(
+    (m) => m.priorityIdentifier === "PRIMARY"
+  ).length;
 
   if (primaryMethodCount === 0) {
     // user with no primary method
-    return formatResponse(422, {})
+    return formatResponse(422, {});
   }
 
   if (primaryMethodCount > 1) {
     // user with more than one primary method
-    return formatResponse(409, {})
+    return formatResponse(409, {});
   }
 
-  const appMethodCount = response.filter(m => m.mfaMethodType === "AUTH_APP").length
+  const appMethodCount = response.filter(
+    (m) => m.mfaMethodType === "AUTH_APP"
+  ).length;
 
   if (appMethodCount > 1) {
     // user with more than one app method
-    return formatResponse(409, {})
+    return formatResponse(409, {});
   }
 
   return formatResponse(200, response);
 };
 
 export const createMfaMethodHandler = async (
-  event: APIGatewayProxyEvent,
+  event: APIGatewayProxyEvent
 ): Promise<APIGatewayProxyResult> => {
   const {
     email,
@@ -58,13 +68,24 @@ export const createMfaMethodHandler = async (
       mfaMethodType = undefined,
     } = {},
   } = JSON.parse(event.body || "{}");
+
   try {
+    const userId = await getUserIdFromEvent(event);
+    const userScenario = getUserScenario(userId, "httpResponse");
+    const { code: responseCode, message: responseMessage } = userScenario || {};
+
+    if (responseCode && responseCode !== 200) {
+      return formatResponse(responseCode, {
+        error: responseMessage || "Unknown error",
+      });
+    }
+
     validateFields(
       { email, otp, credential, priorityIdentifier, mfaMethodType },
       {
         priorityIdentifier: /^(PRIMARY|SECONDARY)$/,
         mfaMethodType: /^(AUTH_APP|SMS)$/,
-      },
+      }
     );
   } catch (e) {
     return formatResponse(400, { error: (e as Error).message });
@@ -74,10 +95,20 @@ export const createMfaMethodHandler = async (
 };
 
 export const updateMfaMethodHandler = async (
-  event: APIGatewayProxyEvent,
+  event: APIGatewayProxyEvent
 ): Promise<APIGatewayProxyResult> => {
   try {
+    const userId = await getUserIdFromEvent(event);
+    const userScenario = getUserScenario(userId, "httpResponse");
+    const { code: responseCode, message: responseMessage } = userScenario || {};
+
+    if (responseCode && responseCode !== 200) {
+      return formatResponse(responseCode, {
+        error: responseMessage || "Unknown error",
+      });
+    }
     assert(event.body, "no body provided");
+
     const body = JSON.parse(event.body);
     const mfaIdentifier = event.pathParameters?.mfaIdentifier;
     const {
@@ -96,7 +127,7 @@ export const updateMfaMethodHandler = async (
       {
         priorityIdentifier: /^(PRIMARY|SECONDARY)$/,
         mfaMethodType: /^(AUTH_APP|SMS)$/,
-      },
+      }
     );
 
     const response = {
@@ -106,6 +137,7 @@ export const updateMfaMethodHandler = async (
       endPoint,
       methodVerified,
     };
+
     return formatResponse(200, response);
   } catch (error) {
     return formatResponse(500, { error: (error as Error).message });

--- a/src/oidc/userinfo.ts
+++ b/src/oidc/userinfo.ts
@@ -1,6 +1,9 @@
 import { APIGatewayProxyEvent } from "aws-lambda";
 import assert from "node:assert/strict";
-import { getUserScenario, getUserIdFromEvent } from "../scenarios/scenarios";
+import {
+  getUserScenario,
+  getUserIdFromEvent,
+} from "../scenarios/scenarios-utils";
 
 export interface Response {
   statusCode: number;

--- a/src/scenarios/scenarios-utils.ts
+++ b/src/scenarios/scenarios-utils.ts
@@ -1,0 +1,74 @@
+import { DynamoDBDocumentClient, QueryCommand } from "@aws-sdk/lib-dynamodb";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import assert from "node:assert/strict";
+import { APIGatewayProxyEvent } from "aws-lambda";
+import { userScenarios } from "./scenarios";
+import { OicdPersistedData, UserScenarios } from "./scenarios.interfaces";
+
+const marshallOptions = {
+  convertClassInstanceToMap: true,
+};
+
+const translateConfig = { marshallOptions };
+const dynamoClient = new DynamoDBClient({});
+const dynamoDocClient = DynamoDBDocumentClient.from(
+  dynamoClient,
+  translateConfig
+);
+
+const parseJwt = (
+  token: string
+): {
+  nonce: string;
+} => {
+  return JSON.parse(Buffer.from(token.split(".")[1], "base64").toString());
+};
+
+export const getUserIdFromEvent = async (
+  event: APIGatewayProxyEvent
+): Promise<string> => {
+  const { TABLE_NAME } = process.env;
+  assert(TABLE_NAME, "TABLE_NAME environment variable not set");
+  assert(
+    event?.headers?.Authorization,
+    "There is no Authorization header in the request"
+  );
+
+  const jwt = parseJwt(event.headers.Authorization);
+
+  const command = new QueryCommand({
+    TableName: TABLE_NAME,
+    IndexName: "OidcNonceIndex",
+    KeyConditionExpression: "nonce = :nonce",
+    ExpressionAttributeValues: {
+      ":nonce": jwt.nonce,
+    },
+    Limit: 1,
+  });
+  const results = await dynamoDocClient.send(command);
+  if (results.Items?.length !== 1) {
+    throw new Error("nonce not found in DB");
+  }
+  return (
+    (results.Items[0] as OicdPersistedData).userId ||
+    "F5CE808F-75AB-4ECD-BBFC-FF9DBF5330FA"
+  );
+};
+
+export const getUserScenario = <
+  T extends keyof UserScenarios[keyof UserScenarios],
+>(
+  userId: keyof typeof userScenarios,
+  scenario: T
+): UserScenarios["default"][T] => {
+  const id = userScenarios[userId] ? userId : "default";
+
+  const response =
+    userScenarios[id][scenario] || userScenarios.default[scenario];
+
+  if ("email" in response) {
+    response.email = `${id}@example.org`;
+  }
+
+  return response;
+};

--- a/src/scenarios/scenarios.interfaces.ts
+++ b/src/scenarios/scenarios.interfaces.ts
@@ -22,7 +22,7 @@ export interface UserScenarios {
       mfaIdentifier: number;
       priorityIdentifier: "PRIMARY" | "SECONDARY";
       mfaMethodType: "SMS" | "AUTH_APP";
-      endPoint: string;
+      endPoint?: string;
       methodVerified: boolean;
     }[];
   };

--- a/src/scenarios/scenarios.interfaces.ts
+++ b/src/scenarios/scenarios.interfaces.ts
@@ -1,0 +1,30 @@
+export interface OicdPersistedData {
+  code: string;
+  nonce: string;
+  userId: string;
+}
+
+export interface UserScenarios {
+  default: {
+    httpResponse: {
+      code: number;
+      message: string;
+    };
+    userinfo: {
+      email: string;
+      email_verified: boolean;
+      sub: string;
+      phone_number: string;
+      phone_number_verified: boolean;
+      updated_at: string;
+    };
+    mfaMethods: {
+      mfaIdentifier: number;
+      priorityIdentifier: "PRIMARY" | "SECONDARY";
+      mfaMethodType: "SMS" | "AUTH_APP";
+      endPoint: string;
+      methodVerified: boolean;
+    }[];
+  };
+  [key: string]: Partial<UserScenarios["default"]>;
+}

--- a/src/scenarios/scenarios.ts
+++ b/src/scenarios/scenarios.ts
@@ -1,49 +1,11 @@
-import { DynamoDBDocumentClient, QueryCommand } from "@aws-sdk/lib-dynamodb";
-import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
-import assert from "node:assert/strict";
-import { APIGatewayProxyEvent } from "aws-lambda";
+import { UserScenarios } from "./scenarios.interfaces";
 
-const marshallOptions = {
-  convertClassInstanceToMap: true,
-};
-
-const translateConfig = { marshallOptions };
-const dynamoClient = new DynamoDBClient({});
-const dynamoDocClient = DynamoDBDocumentClient.from(
-  dynamoClient,
-  translateConfig
-);
-
-interface OicdPersistedData {
-  code: string;
-  nonce: string;
-  userId: string;
-  remove_at: string;
-}
-
-interface UserScenarios {
+export const userScenarios: UserScenarios = {
   default: {
-    userinfo: {
-      email: string;
-      email_verified: boolean;
-      sub: string;
-      phone_number: string;
-      phone_number_verified: boolean;
-      updated_at: string;
-    };
-    mfaMethods: {
-      mfaIdentifier: number;
-      priorityIdentifier: "PRIMARY" | "SECONDARY";
-      mfaMethodType: "SMS" | "AUTH_APP";
-      endPoint?: string;
-      methodVerified: boolean;
-    }[];
-  };
-  [key: string]: Partial<UserScenarios["default"]>;
-}
-
-const userScenarios: UserScenarios = {
-  default: {
+    httpResponse: {
+      code: 200,
+      message: "OK",
+    },
     userinfo: {
       sub: "F5CE808F-75AB-4ECD-BBFC-FF9DBF5330FA",
       email: "your.name@example.com",
@@ -215,61 +177,49 @@ const userScenarios: UserScenarios = {
       },
     ],
   },
-};
-
-const parseJwt = (
-  token: string
-): {
-  nonce: string;
-} => {
-  return JSON.parse(Buffer.from(token.split(".")[1], "base64").toString());
-};
-
-export const getUserIdFromEvent = async (
-  event: APIGatewayProxyEvent
-): Promise<string> => {
-  const { TABLE_NAME } = process.env;
-  assert(TABLE_NAME, "TABLE_NAME environment variable not set");
-  assert(
-    event?.headers?.Authorization,
-    "There is no Authorization header in the request"
-  );
-
-  const jwt = parseJwt(event.headers.Authorization);
-
-  const command = new QueryCommand({
-    TableName: TABLE_NAME,
-    IndexName: "OidcNonceIndex",
-    KeyConditionExpression: "nonce = :nonce",
-    ExpressionAttributeValues: {
-      ":nonce": jwt.nonce,
+  errorMfa400: {
+    httpResponse: {
+      code: 400,
+      message: "BAD REQUEST",
     },
-    Limit: 1,
-  });
-  const results = await dynamoDocClient.send(command);
-  if (results.Items?.length !== 1) {
-    throw new Error("nonce not found in DB");
-  }
-  return (
-    (results.Items[0] as OicdPersistedData).userId ||
-    "F5CE808F-75AB-4ECD-BBFC-FF9DBF5330FA"
-  );
-};
-
-export const getUserScenario = <
-  T extends keyof UserScenarios[keyof UserScenarios],
->(
-  userId: keyof typeof userScenarios,
-  scenario: T
-): UserScenarios["default"][T] => {
-  const id = userScenarios[userId] ? userId : "default";
-
-  const response =
-    userScenarios[id][scenario] || userScenarios.default[scenario];
-
-  if ("email" in response) {
-    response.email = `${id}@example.org`;
-  }
-
-  return response;
+    mfaMethods: [
+      {
+        mfaIdentifier: 1,
+        priorityIdentifier: "PRIMARY",
+        mfaMethodType: "SMS",
+        endPoint: "0123456789",
+        methodVerified: true,
+      },
+    ],
+  },
+  errorMfa404: {
+    httpResponse: {
+      code: 404,
+      message: "NOT FOUND",
+    },
+    mfaMethods: [
+      {
+        mfaIdentifier: 1,
+        priorityIdentifier: "PRIMARY",
+        mfaMethodType: "SMS",
+        endPoint: "0123456789",
+        methodVerified: true,
+      },
+    ],
+  },
+  errorMfa500: {
+    httpResponse: {
+      code: 500,
+      message: "INTERNAL SERVER ERROR",
+    },
+    mfaMethods: [
+      {
+        mfaIdentifier: 1,
+        priorityIdentifier: "PRIMARY",
+        mfaMethodType: "SMS",
+        endPoint: "0123456789",
+        methodVerified: true,
+      },
+    ],
+  },
 };

--- a/template.yaml
+++ b/template.yaml
@@ -166,7 +166,6 @@ Resources:
         Sourcemap: true
         EntryPoints:
           - all-routes.ts
-
   AccountManagementStubFunctionRole:
     Type: AWS::IAM::Role
     Properties:
@@ -177,6 +176,7 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -854,9 +854,9 @@ Resources:
             Resource:
               - !GetAtt DatabaseKmsKey.Arn
 
-#
-# Method Management
-#
+  #
+  # Method Management
+  #
 
   ######################################
   # Method Management API Stub API
@@ -991,27 +991,27 @@ Resources:
               - "sts:AssumeRole"
 
   MethodManagementv1ApiStubPolicy:
-      Type: AWS::IAM::ManagedPolicy
-      Properties:
-        PolicyDocument:
-          Version: "2012-10-17"
-          Statement:
-            - Effect: Allow
-              Action:
-                - dynamodb:Query
-                - dynamodb:GetItem
-              Resource:
-                - !GetAtt OidcStubDataStore.Arn
-                - !Sub
-                  - "${Arn}/*"
-                  - Arn: !GetAtt OidcStubDataStore.Arn
-            - Effect: Allow
-              Action:
-                - kms:Decrypt
-                - kms:GenerateDataKey*
-                - kms:ReEncrypt*
-              Resource:
-                - !GetAtt DatabaseKmsKey.Arn
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - dynamodb:Query
+              - dynamodb:GetItem
+            Resource:
+              - !GetAtt OidcStubDataStore.Arn
+              - !Sub
+                - "${Arn}/*"
+                - Arn: !GetAtt OidcStubDataStore.Arn
+          - Effect: Allow
+            Action:
+              - kms:Decrypt
+              - kms:GenerateDataKey*
+              - kms:ReEncrypt*
+            Resource:
+              - !GetAtt DatabaseKmsKey.Arn
 
   MethodManagementv1ApiStubFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -1053,6 +1053,9 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
         SecurityGroupIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-AWSServicesEndpointSecurityGroupId
+      Environment:
+        Variables:
+          TABLE_NAME: !Ref OidcStubDataTableName
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -1072,6 +1075,7 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+        - !Ref OidcUserInfoApiStubPolicy
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -1098,7 +1102,7 @@ Resources:
       - MethodManagementUpdateV1ApiStubFunctionLogGroup
     Properties:
       FunctionName: !Sub ${Environment}-${AWS::StackName}-method-management-update-v1
-      Architectures: [ "arm64" ]
+      Architectures: ["arm64"]
       CodeUri: src
       Handler: method-management.updateMfaMethodHandler
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
@@ -1122,6 +1126,9 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
         SecurityGroupIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-AWSServicesEndpointSecurityGroupId
+      Environment:
+        Variables:
+          TABLE_NAME: !Ref OidcStubDataTableName
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -1141,6 +1148,7 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+        - !Ref OidcUserInfoApiStubPolicy
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:


### PR DESCRIPTION
## Proposed changes

- Addition of 3 new user scenarios: errorMfa400, errorMfa404, errorMfa500
- Refactored scenario code
- Depending on which user you are logged in with you will always get the error response code for create and update.


### Why did it change

- Ability to test different error codes from the mfa api on our frontend


### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Added parameters to Cloudformation template
- [ ] Added new secret or systems manager parameter
- [x] Added new environment variable

### Permissions

- [x] This PR adds or changes permissions

## Testing

- Added unit test to validate correct error codes are returned
- Validated when updating the cloudwatch logs for the update lambda returned a 400
- NOTE: front end dev console still says there was a 500 error even if a 400 error was suggested. Open to suggestions to further debug, may be front end?
