### PR TITLE
OLH-1849 - add test for adding phone number as backuop method.

### DIFF
--- a/src/tests/method-management/method-management.test.ts
+++ b/src/tests/method-management/method-management.test.ts
@@ -7,7 +7,7 @@ import { components } from "../../method-management/models/schema";
 import {
   userInfoHandler,
   updateMfaMethodHandler,
-  Response,
+  Response, createMfaMethodHandler,
 } from "../../method-management/method-management";
 
 type MfaMethod = components["schemas"]["MfaMethod"];
@@ -106,6 +106,49 @@ describe("MFA Management API Mock", () => {
     expect(mfaMethod[0].methodVerified).toBe(true);
   });
 });
+
+describe("createMfaMethodHandler", () => {
+  const createFakeAPIGatewayProxyEvent = (
+      body: unknown,
+  ): APIGatewayProxyEvent => {
+    return {
+      body: JSON.stringify(body),
+      httpMethod: "POST",
+      path: `/mfa-methods`,
+      pathParameters: null,
+      isBase64Encoded: false,
+      headers: {},
+      multiValueHeaders: {},
+      queryStringParameters: null,
+      multiValueQueryStringParameters: null,
+      stageVariables: null,
+      requestContext:
+          {} as APIGatewayEventRequestContextWithAuthorizer<APIGatewayEventDefaultAuthorizerContext>,
+      resource: "",
+    };
+  };
+
+  test("should return 200 when adding phone number as backup method the request is valid", async () => {
+    const requestBody = {
+      email: "email@email.com",
+      credential: "email",
+      otp: "123456",
+      mfaMethod: {
+        mfaIdentifier: 1,
+        priorityIdentifier: "SECONDARY",
+        mfaMethodType: "SMS",
+        endPoint: "07123456789",
+        methodVerified: true,
+      },
+    };
+    const fakeEvent = createFakeAPIGatewayProxyEvent(requestBody);
+    const response = await createMfaMethodHandler(fakeEvent);
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toMatchObject({});
+  });
+
+});
+
 
 describe("updateMfaMethodHandler", () => {
   const createFakeAPIGatewayProxyEvent = (


### PR DESCRIPTION
## Proposed changes

OLH-1849 - add test for adding phone number as backup method.
https://govukverify.atlassian.net/browse/OLH-1849

### What changed

Add a new unit test and pass in phone number as a backup method

### Why did it change

OLH-1849 - Call the new API when a user adds a phone number as a backup MFA method

### Related links

https://govukverify.atlassian.net/browse/OLH-1849

## Checklists


### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

### Permissions

## Testing


## How to review

