### PR TITLE
OLH-1828 - Add additional checks to Stubs

### DIFF
--- a/src/oidc/validate-token.ts
+++ b/src/oidc/validate-token.ts
@@ -1,0 +1,83 @@
+import {decodeJwt} from "jose";
+
+const SUPPORTED_REDIRECT_URLS = [
+    "https%3A%2F%2Fhome.dev.account.gov.uk%2Fauth%2Fcallback",
+    "http%3A%2F%2Flocalhost%3A6001%2Fauth%2Fcallback",
+    "https%3A%2F%2Fhome.build.account.gov.uk%2Fauth%2Fcallback"
+];
+const ALLOWED_GRANT_TYPES = ['authorization_code'];
+
+export const getIssuerFromJWT = (token: string): string | undefined => {
+    try {
+        const decoded = decodeJwt(token);
+
+        // Check if the decoded object is valid and has the `iss` property
+        if (decoded && decoded.iss) {
+            return decoded.iss;
+        } else {
+            throw new Error('`iss` not found in token');
+        }
+    } catch (error) {
+        console.error('Error decoding JWT:', error);
+        return undefined;
+    }
+};
+
+export const verifyParametersExistAndOnlyOnce = (eventBody: string) => {
+    // verify parameter exist and exist once only
+    if (!existsOnce(eventBody, "client_assertion_type=")
+        || !existsOnce(eventBody, "client_assertion=")
+        || !existsOnce(eventBody, "grant_type=")
+        || !existsOnce(eventBody, "code=")
+        || !existsOnce(eventBody, "redirect_uri=")) {
+        throw new Error(`Missing parameters or duplicate parameter`);
+    }
+};
+
+const existsOnce = (str:string, value: string) => {
+    const regex = new RegExp(value, 'g');
+    const matches = str.match(regex);
+    return matches && matches.length === 1;
+};
+
+export const validateClientIdMatches = (eventBody: string, OIDC_CLIENT_ID: string) => {
+    const regex = /client_assertion=([^ ]+)/
+    const match = eventBody.match(regex);
+    const fromClientAssertion = match ? match[1] : null;
+    if (fromClientAssertion) {
+        const clientAssertion = fromClientAssertion.split("&")[0];
+        const iss = getIssuerFromJWT(clientAssertion);
+        if (iss) {
+            if (OIDC_CLIENT_ID !== iss) {
+                throw new Error(`Invalid client`);
+            }
+        } else {
+            throw new Error(`Invalid client`);
+        }
+    }
+};
+
+
+export const validateRedirectURLSupported = (eventBody: string) => {
+    const regex = /redirect_uri=([^ ]+)/
+    const match = eventBody.match(regex);
+    const redirectUrlPreSplit = match ? match[1] : null;
+    if (redirectUrlPreSplit) {
+        const redirectUrl = redirectUrlPreSplit.split("&")[0];
+        if (!SUPPORTED_REDIRECT_URLS.includes(redirectUrl)) {
+            throw new Error(`Invalid grant - Invalid redirect URL`);
+        }
+    }
+};
+
+export const validateSupportedGrantType = (eventBody: string) => {
+    const regex = /grant_type=([^ ]+)/
+    const match = eventBody.match(regex);
+    const grantPreSplit = match ? match[1] : null;
+    if (grantPreSplit) {
+        const grantType = grantPreSplit.split("&")[0];
+        if (!ALLOWED_GRANT_TYPES.includes(grantType)) {
+            throw new Error('Unauthorized Client - unsupported_grant_type');
+        }
+    }
+};

--- a/src/tests/oidc/token.test.ts
+++ b/src/tests/oidc/token.test.ts
@@ -14,6 +14,8 @@ const oicdPersistedData = {
   nonce,
 };
 
+jest.mock('../../oidc/validate-token');
+
 describe("handler", () => {
   beforeEach(() => {
     process.env.OIDC_CLIENT_ID = "12345";
@@ -40,5 +42,18 @@ describe("handler", () => {
     expect(body.id_token).toContain(
       "eyJraWQiOiJCLVFNVXhkSk9KOHVia21BcmM0aTFTR21mWm5OTmxNLXZhOWgwSEowakNvIiwiYWxnIjoiRVMyNTYifQ."
     );
+  });
+
+  test("returns 500 error response if event body is undefined", async () => {
+    const mockApiEvent: APIGatewayProxyEvent = {
+      body: "",
+    } as never;
+    let errorThrown = false;
+    try {
+      await handler(mockApiEvent);
+    } catch (error) {
+      errorThrown= true;
+    }
+    expect(errorThrown).toBeTruthy();
   });
 });

--- a/src/tests/oidc/validate-token.test.ts
+++ b/src/tests/oidc/validate-token.test.ts
@@ -1,0 +1,73 @@
+import {
+    validateClientIdMatches,
+    validateRedirectURLSupported,
+    validateSupportedGrantType,
+    verifyParametersExistAndOnlyOnce
+} from "../../oidc/validate-token";
+import {decodeJwt} from "jose";
+
+jest.mock('jose', () => ({
+    decodeJwt: jest.fn(),
+}));
+
+describe("validation for token", () => {
+
+    const eventBody = "client_assertion_type=type&client_assertion=xxxx&grant_type=authorization_code&code=xxxx&redirect_uri=xxxxxx"
+
+    beforeEach(() => {
+        process.env.OIDC_CLIENT_ID = "12345";
+        process.env.ENVIRONMENT = "dev";
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test("should throw if duplicate parameters exist", async () => {
+        const withAdditionalParam = "client_assertion_type=xxxsxss&" + eventBody
+        expect(() => verifyParametersExistAndOnlyOnce(withAdditionalParam)).toThrow('Missing parameters or duplicate parameter');
+    });
+
+    test("should throw an error if not all expected parameters exist", async () => {
+        const withMissingParams = "&client_assertion=xxxx&grant_type=authorization_code&code=xxxx&redirect_uri=xxxxxx"
+        expect(() => verifyParametersExistAndOnlyOnce(withMissingParams)).toThrow('Missing parameters or duplicate parameter');
+    });
+
+    test("should ensure invalid redirect URL throws an error", async () => {
+        const withInvalidRedirectUrl = "&client_assertion=xxxx&grant_type=authorization_code&code=xxxx&redirect_uri=xxxxx"
+        expect(() => validateRedirectURLSupported(withInvalidRedirectUrl)).toThrow('Invalid grant - Invalid redirect URL');
+    });
+
+    test("should ensure dev redirect url works", async () => {
+        const withInvalidRedirectUrl = "&client_assertion=xxxx&grant_type=authorization_code&code=xxxx&redirect_uri=https%3A%2F%2Fhome.dev.account.gov.uk%2Fauth%2Fcallback"
+        expect(() => validateRedirectURLSupported(withInvalidRedirectUrl)).not.toThrow('Invalid grant - Invalid redirect URL');
+    });
+
+    test("should ensure localhost redirect url works", async () => {
+        const withInvalidRedirectUrl = "&client_assertion=xxxx&grant_type=authorization_code&code=xxxx&redirect_uri=http%3A%2F%2Flocalhost%3A6001%2Fauth%2Fcallback"
+        expect(() => validateRedirectURLSupported(withInvalidRedirectUrl)).not.toThrow('Invalid grant - Invalid redirect URL');
+    });
+
+    test("should ensure build redirect url works", async () => {
+        const withInvalidRedirectUrl = "&client_assertion=xxxx&grant_type=authorization_code&code=xxxx&redirect_uri=https%3A%2F%2Fhome.build.account.gov.uk%2Fauth%2Fcallback"
+        expect(() => validateRedirectURLSupported(withInvalidRedirectUrl)).not.toThrow('Invalid grant - Invalid redirect URL');
+    });
+
+    test("should ensure grant type supported", async () => {
+        const withInvalidGrantType = "&client_assertion=xxxx&grant_type=xxxxx&code=xxxx&redirect_uri=xxxxx"
+        expect(() => validateSupportedGrantType(withInvalidGrantType)).toThrow('Unauthorized Client - unsupported_grant_type');
+    });
+
+    test("should ensure client id matches expected", async () => {
+        const mockedDecodeJwt = decodeJwt as jest.Mock;
+        const mockDecodedToken = { iss: 'mockIssuer' };
+        mockedDecodeJwt.mockReturnValue(mockDecodedToken);
+        const withNonMatchingClientId = "&client_assertion=mockToken&grant_type=xxxxx&code=xxxx&redirect_uri=xxxxx"
+
+
+        expect(() => validateClientIdMatches(withNonMatchingClientId, "invalid issuer")).toThrow('Invalid client');
+
+        expect(mockedDecodeJwt).toHaveBeenCalledWith("mockToken");
+
+    });
+});


### PR DESCRIPTION
## Proposed changes

OLH-1828 - Add additional checks to Stubs to validate the client assertion token

### What changed

Before generating a token, the stub now checks that

1. All required parameters are provided in the /token call
2. No duplication of parameters in the /token call
3. client assertion JWT token is parsable and retrieves the issuer
4. Verifies issuers matches the client id for the environment
5. Verifies redirect URL is supported by the stubs
6. Verifies grant type provided is supported


### Why did it change
So that OIDC checks in the dev environment using stubs can match as closely as possible to the same check live oidc performs before validating a token request and returning the rewuired access token

### Related links

https://govukverify.atlassian.net/browse/OLH-1930
https://docs.sign-in.service.gov.uk/integrate-with-integration-environment/authenticate-your-user/#error-handling-for-make-a-token-request
<!-- List any related ADRs or RFCs -->

## Checklists

Verify in the dev environment that this new checkes does not breakd evelopment environment and requests for token are passing.

### Environment variables or secrets
- [ ] No environment variables or secrets were added or changed

### Permissions


## Testing

Deploy to dev and ensure attempt to generate token from the stubs are passing.
## How to review