### PR TITLE
BAU: Remove `updated_at` from userinfo response

### DIFF
--- a/docs/oidc/openapi.yaml
+++ b/docs/oidc/openapi.yaml
@@ -155,6 +155,3 @@ components:
           example: "07777 777777"
         phone_verified:
           type: boolean
-        updated_at:
-          type: string
-          example: "1687765582"

--- a/src/scenarios/scenarios.interfaces.ts
+++ b/src/scenarios/scenarios.interfaces.ts
@@ -18,7 +18,6 @@ export interface UserScenarios {
       sub: string;
       phone_number: string;
       phone_number_verified: boolean;
-      updated_at: string;
     };
     mfaMethods: components["schemas"]["MfaMethod"][];
   };

--- a/src/scenarios/scenarios.ts
+++ b/src/scenarios/scenarios.ts
@@ -12,7 +12,6 @@ export const userScenarios: UserScenarios = {
       email_verified: true,
       phone_number: "1234567890",
       phone_number_verified: true,
-      updated_at: Date.now().toString(),
     },
     mfaMethods: [
       {


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

Remove `updated_at` from userinfo response. 

### Why did it change

This field is an optional one in the OIDC spec. Our public tech docs say it's present in our real response, but this is a mistake. In the real version of our OIDC IdP we don't include `updated_at`.

I couldn't find any reference to us using this value in the frontend (which makes sense if it's not provided) so this PR won't break our pre-staging environments.

### Related links

See [this Slack conversation](https://gds.slack.com/archives/C012GEZBZM0/p1720706277498139).

## Checklists

<!-- Merging this PR deploys the stubs. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed
