### PR TITLE
OLH-1966 Stub updates for make backup MFA method the default MFA method

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -36,8 +36,8 @@
 
 ## Testing
 
-<!-- Provide a summary of any manual testing you've done, for example deploying the branch to dev -->
+<!-- Provide a summary of any manual testing you've done, for example, deploying the branch to dev -->
 
 ## How to review
 
-<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->
+<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->

--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,1 @@
+echo "husky - `#!/usr/bin/env sh` and `. "$(dirname -- "$0")/_/husky.sh"` lines in hooks are DEPRECATED and won't be supported in v10. You can remove these two lines for even simpler scripts"

--- a/src/common/validation.ts
+++ b/src/common/validation.ts
@@ -1,13 +1,17 @@
 import assert from "node:assert/strict";
 
 export const validateFields = (
-  fields: { [key: string]: string | undefined },
+  fields: { [key: string]: string | number | undefined },
   checks: { [key: string]: RegExp }
 ) => {
   Object.entries(fields).forEach(([key, value]) => {
     assert(value, `no ${key} provided`);
     if (checks[key]) {
-      assert.match(value, checks[key], `invalid ${key}`);
+      if (typeof value === "string") {
+        assert.match(value, checks[key], `invalid ${key}`);
+      } else {
+        assert.match(String(value), checks[key], `invalid ${key}`);
+      }
     }
   });
 };

--- a/src/method-management/models/schema.d.ts
+++ b/src/method-management/models/schema.d.ts
@@ -5,62 +5,26 @@
 
 export interface paths {
   "/mfa-methods/retrieve": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
     /**
      * Retrieves the list of MFA Methods for a user
      * @description Retrieve mfaMethods that match criteria in the MFASearchRequest in the request body
      */
     post: operations["mfa-methods-retrieve"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
   };
   "/mfa-methods": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** @description Creates an mfa method. A new MFA Method cannot be created as DEFAULT, it must be BACKUP and promoted at a later stage */
+    /** @description Creates an mfa method. A new MFA Method cannot be created as PRIMARY, it must be SECONDARY and promoted at a later stage */
     post: operations["mfa-method-create"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
   };
   "/mfa-methods/{mfaIdentifier}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    /** @description Updates an mfa method. If the MFA method is updated to 'DEFAULT', the current 'DEFAULT' gets relegated to secondary. */
+    /** @description Updates an mfa method. If the MFA method is updated to 'PRIMARY', the current 'PRIMARY' gets relegated to secondary. */
     put: operations["mfa-methods-update"];
-    post?: never;
-    /** @description Deletes the mfa method identified by the mfa identifier. Cannot delete an identifier that is 'DEFAULT'. */
+    /** @description Deletes the mfa method identified by the mfa identifier. Cannot delete an identifier that is 'PRIMARY'. */
     delete: operations["mfa-method-delete"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
   };
 }
+
 export type webhooks = Record<string, never>;
+
 export interface components {
   schemas: {
     /** @enum {string} */
@@ -86,23 +50,27 @@ export interface components {
       mfaMethodType?: "AUTH_APP";
       credential?: string;
     };
-    /** @example {
-     *       "priorityIdentifier": "DEFAULT",
-     *       "mfaMethodType": "AUTH_APP",
-     *       "endPoint": "n/a"
-     *     } */
+    /**
+     * @example {
+     *   "priorityIdentifier": "DEFAULT",
+     *   "mfaMethodType": "AUTH_APP",
+     *   "endPoint": "n/a"
+     * }
+     */
     MfaMethodCreate: {
       priorityIdentifier: components["schemas"]["PriorityEnum"];
       mfaMethodType: components["schemas"]["MethodTypeEnum"];
       endPoint?: string;
       credential?: string;
     };
-    /** @example {
-     *       "mfaIdentifier": 1,
-     *       "priorityIdentifier": "DEFAULT",
-     *       "mfaMethodType": "SMS",
-     *       "endPoint": "070"
-     *     } */
+    /**
+     * @example {
+     *   "mfaIdentifier": 1,
+     *   "priorityIdentifier": "DEFAULT",
+     *   "mfaMethodType": "SMS",
+     *   "endPoint": "070"
+     * }
+     */
     MfaMethodUpdate: {
       mfaIdentifier: number;
       priorityIdentifier: components["schemas"]["PriorityEnum"];
@@ -110,39 +78,45 @@ export interface components {
       credential?: string;
       endPoint?: string;
     };
-    /** @example {
-     *       "email": "testusersearching@searchersexampledomain.co.uk"
-     *     } */
+    /**
+     * @example {
+     *   "email": "testusersearching@searchersexampledomain.co.uk"
+     * }
+     */
     MfaSearchRequest: {
       email: string;
     };
-    /** @example {
-     *       "email": "testuser@testexampledomain.co.uk",
-     *       "credential": "???",
-     *       "otp": "123456",
-     *       "mfaMethod": {
-     *         "priorityIdentifier": "DEFAULT",
-     *         "mfaMethodType": "AUTH_APP",
-     *         "endPoint": "n/a"
-     *       },
-     *       "methodVerified": true
-     *     } */
+    /**
+     * @example {
+     *   "email": "testuser@testexampledomain.co.uk",
+     *   "credential": "???",
+     *   "otp": "123456",
+     *   "mfaMethod": {
+     *     "priorityIdentifier": "DEFAULT",
+     *     "mfaMethodType": "AUTH_APP",
+     *     "endPoint": "n/a"
+     *   },
+     *   "methodVerified": true
+     * }
+     */
     MfaMethodCreateRequest: {
       email: string;
       credential: string;
       otp: string;
       mfaMethod: components["schemas"]["MfaMethodCreate"];
     };
-    /** @example {
-     *       "email": "testuser@testexampledomain.co.uk",
-     *       "otp": "123456",
-     *       "mfaMethod": {
-     *         "mfaIdentifier": 1,
-     *         "priorityIdentifier": "DEFAULT",
-     *         "mfaMethodType": "AUTH_APP",
-     *         "endPoint": "n/a"
-     *       }
-     *     } */
+    /**
+     * @example {
+     *   "email": "testuser@testexampledomain.co.uk",
+     *   "otp": "123456",
+     *   "mfaMethod": {
+     *     "mfaIdentifier": 1,
+     *     "priorityIdentifier": "DEFAULT",
+     *     "mfaMethodType": "AUTH_APP",
+     *     "endPoint": "n/a"
+     *   }
+     * }
+     */
     MfaMethodUpdateRequest: {
       email: string;
       otp: string;
@@ -184,15 +158,17 @@ export interface components {
   headers: never;
   pathItems: never;
 }
+
 export type $defs = Record<string, never>;
+
+export type external = Record<string, never>;
+
 export interface operations {
+  /**
+   * Retrieves the list of MFA Methods for a user
+   * @description Retrieve mfaMethods that match criteria in the MFASearchRequest in the request body
+   */
   "mfa-methods-retrieve": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
     requestBody: {
       content: {
         "application/json": components["schemas"]["MfaSearchRequest"];
@@ -201,49 +177,32 @@ export interface operations {
     responses: {
       /** @description Successful Operation.  The retrieve query was accepted and the response contains all matching MFAMethods. */
       200: {
-        headers: {
-          [name: string]: unknown;
-        };
         content: {
           "application/json": components["schemas"]["MfaMethod"][];
         };
       };
       /** @description Bad Request */
       400: {
-        headers: {
-          [name: string]: unknown;
-        };
         content: {
           "application/json": components["schemas"]["ValidationProblem"];
         };
       };
       /** @description Not Found */
       404: {
-        headers: {
-          [name: string]: unknown;
-        };
         content: {
           "application/json": components["schemas"]["ProblemDetail"];
         };
       };
       /** @description Search not available */
       500: {
-        headers: {
-          [name: string]: unknown;
-        };
         content: {
           "application/json": components["schemas"]["ProblemDetail"];
         };
       };
     };
   };
+  /** @description Creates an mfa method. A new MFA Method cannot be created as PRIMARY, it must be SECONDARY and promoted at a later stage */
   "mfa-method-create": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
     requestBody: {
       content: {
         "application/json": components["schemas"]["MfaMethodCreateRequest"];
@@ -252,41 +211,30 @@ export interface operations {
     responses: {
       /** @description MFA Method Created */
       200: {
-        headers: {
-          [name: string]: unknown;
-        };
         content: {
           "application/json": components["schemas"]["MfaMethod"];
         };
       };
       /** @description Bad Request */
       400: {
-        headers: {
-          [name: string]: unknown;
-        };
         content: {
           "application/json": components["schemas"]["ProblemDetail"];
         };
       };
       /** @description MFA Method could not be created */
       500: {
-        headers: {
-          [name: string]: unknown;
-        };
         content: {
           "application/json": components["schemas"]["ProblemDetail"];
         };
       };
     };
   };
+  /** @description Updates an mfa method. If the MFA method is updated to 'PRIMARY', the current 'PRIMARY' gets relegated to secondary. */
   "mfa-methods-update": {
     parameters: {
-      query?: never;
-      header?: never;
       path: {
         mfaIdentifier: string;
       };
-      cookie?: never;
     };
     requestBody: {
       content: {
@@ -296,76 +244,52 @@ export interface operations {
     responses: {
       /** @description MFA Method Updated */
       200: {
-        headers: {
-          [name: string]: unknown;
-        };
         content: {
           "application/json": components["schemas"]["MfaMethod"];
         };
       };
       /** @description MFA Method not Found */
       404: {
-        headers: {
-          [name: string]: unknown;
-        };
         content: {
           "application/json": components["schemas"]["ProblemDetail"];
         };
       };
       /** @description MFA Method could not be updated */
       500: {
-        headers: {
-          [name: string]: unknown;
-        };
         content: {
           "application/json": components["schemas"]["ProblemDetail"];
         };
       };
     };
   };
+  /** @description Deletes the mfa method identified by the mfa identifier. Cannot delete an identifier that is 'PRIMARY'. */
   "mfa-method-delete": {
     parameters: {
-      query?: never;
-      header?: never;
       path: {
         mfaIdentifier: string;
       };
-      cookie?: never;
     };
-    requestBody?: never;
     responses: {
       /** @description MFA Method Deleted */
       200: {
-        headers: {
-          [name: string]: unknown;
-        };
         content: {
           "application/json": unknown;
         };
       };
       /** @description MFA Method Not found */
       404: {
-        headers: {
-          [name: string]: unknown;
-        };
         content: {
           "application/json": components["schemas"]["ProblemDetail"];
         };
       };
       /** @description Cannot delete a Primary MFA Method */
       409: {
-        headers: {
-          [name: string]: unknown;
-        };
         content: {
           "application/json": components["schemas"]["ProblemDetail"];
         };
       };
       /** @description MFA Method could not be deleted */
       500: {
-        headers: {
-          [name: string]: unknown;
-        };
         content: {
           "application/json": components["schemas"]["ProblemDetail"];
         };

--- a/src/tests/common/validation.test.ts
+++ b/src/tests/common/validation.test.ts
@@ -35,4 +35,26 @@ describe("validateFields Function", () => {
     };
     expect(() => validateFields(fields, checks)).toThrow(/invalid firstName/);
   });
+
+  it("should validate numeric fields when converted to string and match the regular expression", () => {
+    const fields = {
+      mfaIdentifier: 2,
+    };
+    const checks = {
+      mfaIdentifier: /^[0-9]+$/,
+    };
+    expect(() => validateFields(fields, checks)).not.toThrow(Error);
+  });
+
+  it("should throw an error when numeric field does not match the regular expression", () => {
+    const fields = {
+      mfaIdentifier: 2.5,
+    };
+    const checks = {
+      mfaIdentifier: /^[0-9]+$/,
+    };
+    expect(() => validateFields(fields, checks)).toThrow(
+      /invalid mfaIdentifier/
+    );
+  });
 });


### PR DESCRIPTION
## Proposed changes

[OLH-1966] Stub updates for make backup MFA method the default MFA method

### What changed

Updated schema from latest openapi-specs repo.
Added more validation for missing required fields and added 404 and 500 handlers

### Why did it change

To make the stubs behave as the actual openapi-specs endpoint

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR deploys the stubs. Please answer accurately. -->

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed


### Permissions

- [ ] This PR adds or changes permissions

## Testing

Tested locally and in dev

## How to review

Send payloads that match 404 and 500 server errors from API schema page https://symmetrical-adventure-q4wnm7e.pages.github.io/?urls.primaryName=openapi-specs-method-management-api#/2FAManagement/mfa-methods-update


[OLH-1966]: https://govukverify.atlassian.net/browse/OLH-1966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ