### PR TITLE
PSREDEV-1270: added TxmaDummyInputQueue values for demo env

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -41,6 +41,10 @@ Mappings:
     demo:
       url: "https://home.demo.account.gov.uk"
   TxmaDummyInputQueue:
+    demo:
+      QueueArn: "arn:aws:sqs:eu-west-2:654654326096:home-backend-TxMAInputDummyQueue-aydSI6PG6u3g"
+      KeyArn: "arn:aws:kms:eu-west-2:654654326096:key/35234388-c3dd-4dce-85f0-cb9fef379757"
+      QueueUrl: "https://sqs.eu-west-2.amazonaws.com/654654326096/home-backend-TxMAInputDummyQueue-aydSI6PG6u3g"
     dev:
       QueueArn: "arn:aws:sqs:eu-west-2:985326104449:account-mgmt-backend-TxMAInputDummyQueue-lZORy5gLrQ4D"
       KeyArn: "arn:aws:kms:eu-west-2:985326104449:key/290ec47d-887b-4a99-a81c-4f5c3e0b04ee"


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `
[[PSREDEV-1270](https://govukverify.atlassian.net/browse/PSREDEV-1270)]

### What changed

Added QueueArn, KeyArn, and QueueUrl values for the TxmaDummyInputQueue for the demo environment.

### Why did it change

Needed to add these values in to fix an error in the home-stubs-pipeline in di-account-test.

## Checklists

<!-- Merging this PR deploys the stubs. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Permissions

- [ ] This PR adds or changes permissions

## Testing

<!-- Provide a summary of any manual testing you've done, for example, deploying the branch to dev -->

Deployed branch to the demo environment and the the error in the pipeline was fixed. 

## How to review

<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->


[PSREDEV-1270]: https://govukverify.atlassian.net/browse/PSREDEV-1270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ