### PR TITLE
OLH-2019 Incorrect OTP scenario

### DIFF
--- a/src/scenarios/scenarios.ts
+++ b/src/scenarios/scenarios.ts
@@ -123,7 +123,7 @@ export const userScenarios: UserScenarios = {
       },
     ],
   },
-  userOtpNewPhoneNumberSameAsExisting: {
+  userNewPhoneNumberSameAsExisting: {
     otpNotification: {
       success: false,
       code: ERROR_CODES.NEW_PHONE_NUMBER_SAME_AS_EXISTING
@@ -139,6 +139,12 @@ export const userScenarios: UserScenarios = {
         methodVerified: true,
       },
     ]
+  },
+  userOtpCodeWrong: {
+    httpResponse: {
+      code: 400,
+      message: "OTP incorrect"
+    }
   },
   errorNoMfaMethods: {
     mfaMethods: [],


### PR DESCRIPTION
Add a testing scenario to test the case where the user enter's the OTP code incorrectly (for example, when changing their phone number)