### PR TITLE
OLH-1996 - Stub updates for replace a default MFA method

### DIFF
--- a/src/method-management/method-management.ts
+++ b/src/method-management/method-management.ts
@@ -132,11 +132,9 @@ export const updateMfaMethodHandler = async (
 
     const response: components["schemas"]["MfaMethod"] = {
       mfaIdentifier: Number(mfaIdentifier),
-      priorityIdentifier:
-        priorityIdentifier === "BACKUP" ? "DEFAULT" : "BACKUP",
+      priorityIdentifier: priorityIdentifier,
       method:
-        mfaMethodType === "SMS"
-          ? {
+        mfaMethodType === "SMS" ? {
               mfaMethodType,
               phoneNumber: endPoint,
             }
@@ -144,7 +142,7 @@ export const updateMfaMethodHandler = async (
               mfaMethodType,
               credential: endPoint,
             },
-      methodVerified: true,
+      methodVerified: true
     };
 
     return formatResponse(200, response);

--- a/src/method-management/method-management.ts
+++ b/src/method-management/method-management.ts
@@ -134,7 +134,8 @@ export const updateMfaMethodHandler = async (
       mfaIdentifier: Number(mfaIdentifier),
       priorityIdentifier: priorityIdentifier,
       method:
-        mfaMethodType === "SMS" ? {
+        mfaMethodType === "SMS"
+          ? {
               mfaMethodType,
               phoneNumber: endPoint,
             }
@@ -142,7 +143,7 @@ export const updateMfaMethodHandler = async (
               mfaMethodType,
               credential: endPoint,
             },
-      methodVerified: true
+      methodVerified: true,
     };
 
     return formatResponse(200, response);

--- a/src/tests/method-management/method-management.test.ts
+++ b/src/tests/method-management/method-management.test.ts
@@ -257,7 +257,7 @@ describe("updateMfaMethodHandler", () => {
     expect(response.statusCode).toBe(200);
     expect(JSON.parse(response.body)).toMatchObject({
       mfaIdentifier: 1,
-      priorityIdentifier: "DEFAULT",
+      priorityIdentifier: "BACKUP",
       method: {
         mfaMethodType: "SMS",
         phoneNumber: "07123456789",
@@ -284,7 +284,7 @@ describe("updateMfaMethodHandler", () => {
     expect(response.statusCode).toBe(200);
     expect(JSON.parse(response.body)).toMatchObject({
       mfaIdentifier: 1,
-      priorityIdentifier: "BACKUP",
+      priorityIdentifier: "DEFAULT",
       method: {
         mfaMethodType: "AUTH_APP",
         credential: "ABC",
@@ -310,7 +310,7 @@ describe("updateMfaMethodHandler", () => {
     expect(response.statusCode).toBe(200);
     expect(JSON.parse(response.body)).toMatchObject({
       mfaIdentifier: 1,
-      priorityIdentifier: "BACKUP",
+      priorityIdentifier: "DEFAULT",
       method: {
         mfaMethodType: "SMS",
         phoneNumber: "07111111111",


### PR DESCRIPTION
## Proposed changes

OLH-1996 - Stub updates for replace a default MFA method
https://govukverify.atlassian.net/browse/OLH-1996

### What changed

Update stub to permit change of default method

### Why did it change

So that we can simulate calls to change the default MFA method of a user prior to the real API being available.

### Related links


## Checklists

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

### Permissions

## Testing

Deploy to dev, attempt to change default method and ensure it works.

## How to review
