### PR TITLE
OLH-2065-help-performance-testing-team-fix-99-test-failures-after-introducing-the-stub-page

### DIFF
--- a/src/scenarios/scenarios-utils.ts
+++ b/src/scenarios/scenarios-utils.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import { APIGatewayProxyEvent, APIGatewayProxyEventV2 } from "aws-lambda";
 import { userScenarios } from "./scenarios";
 import { OicdPersistedData, UserScenarios } from "./scenarios.interfaces";
+import { v4 as uuidv4 } from "uuid";
 
 const marshallOptions = {
   convertClassInstanceToMap: true,
@@ -67,6 +68,10 @@ export const getUserScenario = <
 
   if ("email" in response) {
     response.email = `${id}@example.org`;
+  }
+
+  if ("sub" in response) {
+    response.sub = uuidv4();
   }
 
   return response;

--- a/template.yaml
+++ b/template.yaml
@@ -174,7 +174,7 @@ Resources:
       Handler: all-routes.handler
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
-      MemorySize: 128
+      MemorySize: 256
       ReservedConcurrentExecutions: 30
       Runtime: nodejs18.x
       Role: !GetAtt AccountManagementStubFunctionRole.Arn
@@ -450,7 +450,7 @@ Resources:
       Handler: authorize.selectScenarioHandler
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
-      MemorySize: 128
+      MemorySize: 256
       ReservedConcurrentExecutions: 30
       Runtime: nodejs18.x
       Role: !GetAtt BaseLambdaRole.Arn
@@ -502,7 +502,7 @@ Resources:
       Handler: authorize.handler
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
-      MemorySize: 128
+      MemorySize: 256
       ReservedConcurrentExecutions: 30
       Runtime: nodejs18.x
       Role: !GetAtt OidcAuthorizeApiStubFunctionRole.Arn
@@ -617,7 +617,7 @@ Resources:
       Handler: userinfo.handler
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
-      MemorySize: 128
+      MemorySize: 256
       ReservedConcurrentExecutions: 30
       Runtime: nodejs18.x
       Role: !GetAtt OidcUserInfoApiStubFunctionRole.Arn
@@ -695,7 +695,7 @@ Resources:
       Handler: configuration.handler
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
-      MemorySize: 128
+      MemorySize: 256
       ReservedConcurrentExecutions: 30
       Runtime: nodejs18.x
       Role: !GetAtt BaseLambdaRole.Arn
@@ -750,7 +750,7 @@ Resources:
       Handler: jwks.handler
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
-      MemorySize: 128
+      MemorySize: 256
       ReservedConcurrentExecutions: 30
       Runtime: nodejs18.x
       Role: !GetAtt BaseLambdaRole.Arn
@@ -802,7 +802,7 @@ Resources:
       Handler: token.handler
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
-      MemorySize: 128
+      MemorySize: 256
       ReservedConcurrentExecutions: 30
       Runtime: nodejs18.x
       Role: !GetAtt OidcTokenApiStubFunctionRole.Arn
@@ -994,7 +994,7 @@ Resources:
       Handler: method-management.userInfoHandler
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
-      MemorySize: 128
+      MemorySize: 256
       ReservedConcurrentExecutions: 30
       Runtime: nodejs18.x
       Role: !GetAtt MethodManagementv1LambdaRole.Arn
@@ -1046,7 +1046,7 @@ Resources:
       Handler: method-management.createMfaMethodHandler
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
-      MemorySize: 128
+      MemorySize: 256
       ReservedConcurrentExecutions: 30
       Runtime: nodejs18.x
       Role: !GetAtt MethodManagementv1LambdaRole.Arn
@@ -1098,7 +1098,7 @@ Resources:
       Handler: method-management.updateMfaMethodHandler
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
-      MemorySize: 128
+      MemorySize: 256
       ReservedConcurrentExecutions: 30
       Runtime: nodejs18.x
       Role: !GetAtt MethodManagementv1LambdaRole.Arn
@@ -1150,7 +1150,7 @@ Resources:
       Handler: method-management.deleteMethodHandler
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
-      MemorySize: 128
+      MemorySize: 256
       ReservedConcurrentExecutions: 30
       Runtime: nodejs18.x
       Role: !GetAtt MethodManagementv1LambdaRole.Arn

--- a/template.yaml
+++ b/template.yaml
@@ -174,7 +174,7 @@ Resources:
       Handler: all-routes.handler
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
-      MemorySize: 256
+      MemorySize: 128
       ReservedConcurrentExecutions: 30
       Runtime: nodejs18.x
       Role: !GetAtt AccountManagementStubFunctionRole.Arn
@@ -450,7 +450,7 @@ Resources:
       Handler: authorize.selectScenarioHandler
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
-      MemorySize: 256
+      MemorySize: 128
       ReservedConcurrentExecutions: 30
       Runtime: nodejs18.x
       Role: !GetAtt BaseLambdaRole.Arn
@@ -502,7 +502,7 @@ Resources:
       Handler: authorize.handler
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
-      MemorySize: 256
+      MemorySize: 160
       ReservedConcurrentExecutions: 30
       Runtime: nodejs18.x
       Role: !GetAtt OidcAuthorizeApiStubFunctionRole.Arn
@@ -617,7 +617,7 @@ Resources:
       Handler: userinfo.handler
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
-      MemorySize: 256
+      MemorySize: 128
       ReservedConcurrentExecutions: 30
       Runtime: nodejs18.x
       Role: !GetAtt OidcUserInfoApiStubFunctionRole.Arn
@@ -695,7 +695,7 @@ Resources:
       Handler: configuration.handler
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
-      MemorySize: 256
+      MemorySize: 128
       ReservedConcurrentExecutions: 30
       Runtime: nodejs18.x
       Role: !GetAtt BaseLambdaRole.Arn
@@ -750,7 +750,7 @@ Resources:
       Handler: jwks.handler
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
-      MemorySize: 256
+      MemorySize: 128
       ReservedConcurrentExecutions: 30
       Runtime: nodejs18.x
       Role: !GetAtt BaseLambdaRole.Arn
@@ -802,7 +802,7 @@ Resources:
       Handler: token.handler
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
-      MemorySize: 256
+      MemorySize: 150
       ReservedConcurrentExecutions: 30
       Runtime: nodejs18.x
       Role: !GetAtt OidcTokenApiStubFunctionRole.Arn
@@ -994,7 +994,7 @@ Resources:
       Handler: method-management.userInfoHandler
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
-      MemorySize: 256
+      MemorySize: 128
       ReservedConcurrentExecutions: 30
       Runtime: nodejs18.x
       Role: !GetAtt MethodManagementv1LambdaRole.Arn
@@ -1046,7 +1046,7 @@ Resources:
       Handler: method-management.createMfaMethodHandler
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
-      MemorySize: 256
+      MemorySize: 128
       ReservedConcurrentExecutions: 30
       Runtime: nodejs18.x
       Role: !GetAtt MethodManagementv1LambdaRole.Arn
@@ -1098,7 +1098,7 @@ Resources:
       Handler: method-management.updateMfaMethodHandler
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
-      MemorySize: 256
+      MemorySize: 128
       ReservedConcurrentExecutions: 30
       Runtime: nodejs18.x
       Role: !GetAtt MethodManagementv1LambdaRole.Arn
@@ -1150,7 +1150,7 @@ Resources:
       Handler: method-management.deleteMethodHandler
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
-      MemorySize: 256
+      MemorySize: 128
       ReservedConcurrentExecutions: 30
       Runtime: nodejs18.x
       Role: !GetAtt MethodManagementv1LambdaRole.Arn


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->
[OLH-2065]: Improve Lambda performance
### What changed
<!-- Describe the changes in detail - the "what"-->
Ran performance tests against dev. Identified Lambda's were under provisioned and rightsized them. Additionally refactored some code so it has better performance.

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
Lambda's were taking 1.8s to run in the 99th percentile. 

### Related links
<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR deploys the stubs. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Permissions

- [ ] This PR adds or changes permissions

## Testing

<!-- Provide a summary of any manual testing you've done, for example, deploying the branch to dev -->
Deployed to Dev. 
Validated performance improvement.

<img width="1387" alt="Screenshot 2024-08-30 at 15 34 36" src="https://github.com/user-attachments/assets/c63bf94e-8656-411d-9367-e4a894d846d4">
<img width="1381" alt="Screenshot 2024-08-30 at 15 37 15" src="https://github.com/user-attachments/assets/216db7d2-07ce-4c93-bcc5-d3cb17d16d29">
<img width="1365" alt="Screenshot 2024-08-30 at 15 36 53" src="https://github.com/user-attachments/assets/d22f0c8a-5401-4424-9f85-e401a04bea92">
<img width="1383" alt="Screenshot 2024-08-30 at 15 35 24" src="https://github.com/user-attachments/assets/a552ca2f-a907-4eec-867f-d7dab30a817b">


## How to review

<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->


[OLH-2065]: https://govukverify.atlassian.net/browse/OLH-2065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ