### PR TITLE
OLH-2114-activity-history-not-being-stored-with-oidc

### DIFF
--- a/src/scenarios/scenarios-utils.ts
+++ b/src/scenarios/scenarios-utils.ts
@@ -4,7 +4,6 @@ import assert from "node:assert/strict";
 import { APIGatewayProxyEvent, APIGatewayProxyEventV2 } from "aws-lambda";
 import { userScenarios } from "./scenarios";
 import { OicdPersistedData, UserScenarios } from "./scenarios.interfaces";
-import { v4 as uuidv4 } from "uuid";
 
 const marshallOptions = {
   convertClassInstanceToMap: true,
@@ -68,10 +67,6 @@ export const getUserScenario = <
 
   if ("email" in response) {
     response.email = `${id}@example.org`;
-  }
-
-  if ("sub" in response) {
-    response.sub = uuidv4();
   }
 
   return response;

--- a/src/scenarios/scenarios.ts
+++ b/src/scenarios/scenarios.ts
@@ -1,4 +1,5 @@
 import { UserScenarios } from "./scenarios.interfaces";
+import { v4 as uuidv4 } from "uuid";
 
 export const ERROR_CODES = {
   NEW_PASSWORD_SAME_AS_EXISTING: 1024,
@@ -299,5 +300,32 @@ export const userScenarios: UserScenarios = {
         methodVerified: true,
       },
     ],
+  },
+  userPerformanceTest: {
+    httpResponse: {
+      code: 200,
+      message: "OK",
+    },
+    userinfo: {
+      sub: uuidv4(),
+      email: "your.name@example.com",
+      email_verified: true,
+      phone_number: "1234567890",
+      phone_number_verified: true,
+    },
+    mfaMethods: [
+      {
+        mfaIdentifier: 0,
+        priorityIdentifier: "DEFAULT",
+        method: {
+          mfaMethodType: "SMS",
+          phoneNumber: "07123456789",
+        },
+        methodVerified: true,
+      },
+    ],
+    otpNotification: {
+      success: true,
+    },
   },
 };


### PR DESCRIPTION
## Proposed changes
[OLH-2114] Resolve activity history

### What changed
created a performance test user with randomly generated session id

### Why did it change
Missing activity history from default user

## Testing
Tested in dev environment

[OLH-2114]: https://govukverify.atlassian.net/browse/OLH-2114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ