### PR TITLE
OLH-2272-update-dependabot-config-for-the-stub-to-group-updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,25 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: daily
+      time: "03:00"
+    target-branch: main
+    labels:
+      - dependabot
+      - dependencies
+    ignore:
+      - dependency-name: "node"
+        versions: ["17.x", "18.x", "19.x"]
+    commit-message:
+      prefix: BAU
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->
[OLH-2272] Update Dependabot config for the stub 

### What changed

<!-- Describe the changes in detail - the "what"-->
Duplicated config from frontend and backend to the stub so updates are grouped.

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
Merging individual branches triggered rebasing which meant additional waiting to resolve dependabot recommendations.

[OLH-2272]: https://govukverify.atlassian.net/browse/OLH-2272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ