### PR TITLE
OLH-2205-performance-testing-implementation-of-overload-protection-library-causing-http-503-errors-optimise-stub-memory

### DIFF
--- a/src/oidc/token.ts
+++ b/src/oidc/token.ts
@@ -78,18 +78,15 @@ export const handler = async (
     throw new Error(`no request body is provided`);
   }
 
-  console.log(`Event body is: ${event.body}`);
-
   verifyParametersExistAndOnlyOnce(event.body);
 
   validateRedirectURLSupported(event.body);
 
   validateSupportedGrantType(event.body);
 
-  const code = event.body.substring(
-    event.body.indexOf("&code=") + 6,
-    event.body.indexOf("&redirect_uri=")
-  );
+  const codeStartIndex = event.body.indexOf("&code=") + 6;
+  const codeEndIndex = event.body.indexOf("&redirect_uri=");
+  const code = event.body.substring(codeStartIndex, codeEndIndex);
 
   const nonce = await persistedNonce(code);
 

--- a/template.yaml
+++ b/template.yaml
@@ -174,7 +174,7 @@ Resources:
       Handler: all-routes.handler
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
-      MemorySize: 128
+      MemorySize: 256
       ReservedConcurrentExecutions: 30
       Runtime: nodejs18.x
       Role: !GetAtt AccountManagementStubFunctionRole.Arn
@@ -502,7 +502,7 @@ Resources:
       Handler: authorize.handler
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
-      MemorySize: 160
+      MemorySize: 256
       ReservedConcurrentExecutions: 30
       Runtime: nodejs18.x
       Role: !GetAtt OidcAuthorizeApiStubFunctionRole.Arn
@@ -617,7 +617,7 @@ Resources:
       Handler: userinfo.handler
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
-      MemorySize: 128
+      MemorySize: 256
       ReservedConcurrentExecutions: 30
       Runtime: nodejs18.x
       Role: !GetAtt OidcUserInfoApiStubFunctionRole.Arn
@@ -802,7 +802,7 @@ Resources:
       Handler: token.handler
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
-      MemorySize: 1024
+      MemorySize: 256
       ReservedConcurrentExecutions: 30
       Runtime: nodejs18.x
       Role: !GetAtt OidcTokenApiStubFunctionRole.Arn
@@ -994,7 +994,7 @@ Resources:
       Handler: method-management.userInfoHandler
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
-      MemorySize: 128
+      MemorySize: 256
       ReservedConcurrentExecutions: 30
       Runtime: nodejs18.x
       Role: !GetAtt MethodManagementv1LambdaRole.Arn


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed
<!-- Describe the changes in detail - the "what"-->
[OLH-22025] Performance Bottleneck - stubs

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
Stubs have been identified as bottlenecks repeatedly. Specifically the token.ts, userInfo.ts and the authorize.ts endpoints.

Increasing memory should alleviate this further.

## Testing

<!-- Provide a summary of any manual testing you've done, for example, deploying the branch to dev -->

## How to review

<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
Deployed to Dev and ran against performance tests. 