### PR TITLE
Olh 2181: Increase provisioned concurrency for oidc scenario lambda

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -251,7 +251,9 @@ Resources:
           - HEAD
           - OPTIONS
           - POST
-      Target: !GetAtt AccountManagementStubFunction.Arn
+      Target: !Join
+        - ":"
+        - [!GetAtt AccountManagementStubFunction.Arn, "live"]
 
   AccountManagementStubApiPermission:
     Type: AWS::Lambda::Permission

--- a/template.yaml
+++ b/template.yaml
@@ -458,7 +458,7 @@ Resources:
       MemorySize: 128
       ReservedConcurrentExecutions: 30
       ProvisionedConcurrencyConfig:
-        ProvisionedConcurrentExecutions: 2
+        ProvisionedConcurrentExecutions: 5
       Runtime: nodejs18.x
       Role: !GetAtt BaseLambdaRole.Arn
       Timeout: 5


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->
[OLH-2181] Increased provisioned concurrency for OIDC Scenario Lambda

### What changed
<!-- Describe the changes in detail - the "what"-->
Increased number of provisioned concurrency instances to 5

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
Cold starts were impacting auth flow which caused signing in to not meet the NFR. Though it is a stub, this will ensure the performance of the site is focused on the actual site.


[OLH-2181]: https://govukverify.atlassian.net/browse/OLH-2181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ