### PR TITLE
OLH-2538: Upgrade Lambda runtime to Node 22

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -69,6 +69,7 @@ Conditions:
 
 Globals:
   Function:
+    Runtime: nodejs22.x
     AutoPublishAlias: live
     CodeSigningConfigArn: !If
       - UseCodeSigning
@@ -177,7 +178,6 @@ Resources:
       PackageType: Zip
       MemorySize: 256
       ReservedConcurrentExecutions: 30
-      Runtime: nodejs18.x
       Role: !GetAtt AccountManagementStubFunctionRole.Arn
       Events:
         sendotp:
@@ -455,7 +455,6 @@ Resources:
       PackageType: Zip
       MemorySize: 128
       ReservedConcurrentExecutions: 30
-      Runtime: nodejs18.x
       Role: !GetAtt BaseLambdaRole.Arn
       Timeout: 5
       Events:
@@ -507,7 +506,6 @@ Resources:
       PackageType: Zip
       MemorySize: 256
       ReservedConcurrentExecutions: 30
-      Runtime: nodejs18.x
       Role: !GetAtt OidcAuthorizeApiStubFunctionRole.Arn
       Timeout: 5
       Environment:
@@ -622,7 +620,6 @@ Resources:
       PackageType: Zip
       MemorySize: 256
       ReservedConcurrentExecutions: 30
-      Runtime: nodejs18.x
       Role: !GetAtt OidcUserInfoApiStubFunctionRole.Arn
       Timeout: 5
       Events:
@@ -700,7 +697,6 @@ Resources:
       PackageType: Zip
       MemorySize: 128
       ReservedConcurrentExecutions: 30
-      Runtime: nodejs18.x
       Role: !GetAtt BaseLambdaRole.Arn
       Events:
         config:
@@ -755,7 +751,6 @@ Resources:
       PackageType: Zip
       MemorySize: 128
       ReservedConcurrentExecutions: 30
-      Runtime: nodejs18.x
       Role: !GetAtt BaseLambdaRole.Arn
       Timeout: 5
       Events:
@@ -807,7 +802,6 @@ Resources:
       PackageType: Zip
       MemorySize: 256
       ReservedConcurrentExecutions: 30
-      Runtime: nodejs18.x
       Role: !GetAtt OidcTokenApiStubFunctionRole.Arn
       Timeout: 5
       Events:
@@ -999,7 +993,6 @@ Resources:
       PackageType: Zip
       MemorySize: 256
       ReservedConcurrentExecutions: 30
-      Runtime: nodejs18.x
       Role: !GetAtt MethodManagementv1LambdaRole.Arn
       Timeout: 5
       Events:
@@ -1051,7 +1044,6 @@ Resources:
       PackageType: Zip
       MemorySize: 128
       ReservedConcurrentExecutions: 30
-      Runtime: nodejs18.x
       Role: !GetAtt MethodManagementv1LambdaRole.Arn
       Timeout: 5
       Events:
@@ -1103,7 +1095,6 @@ Resources:
       PackageType: Zip
       MemorySize: 128
       ReservedConcurrentExecutions: 30
-      Runtime: nodejs18.x
       Role: !GetAtt MethodManagementv1LambdaRole.Arn
       Timeout: 5
       Events:
@@ -1155,7 +1146,6 @@ Resources:
       PackageType: Zip
       MemorySize: 128
       ReservedConcurrentExecutions: 30
-      Runtime: nodejs18.x
       Role: !GetAtt MethodManagementv1LambdaRole.Arn
       Timeout: 5
       Events:


### PR DESCRIPTION


## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

From Node 18 as that's about to be deprecated. Our policy[^1] says we should be on the most recent LTS runtime, so that's Node 22.

This is a safe upgrade as we already run our tests locally and in CI using Node 22.

I've taken the opportunity to move this parameter to the `Globals` object as all these Lambdas use the same runtime.

[^1]: https://team-manual.account.gov.uk/policies/#active-policies
### Why did it change

Node 18 is EOL in September
