### PR TITLE
OLH-2534: Update the MFA API url structure

### DIFF
--- a/src/method-management/method-management.ts
+++ b/src/method-management/method-management.ts
@@ -63,9 +63,9 @@ function handleMFAResponse(response: components["schemas"]["MfaMethod"][]) {
 export const retrieveMfaMethodHandler = async (
   event: APIGatewayProxyEvent
 ): Promise<Response> => {
-  const mfaIdentifier = event.pathParameters?.mfaIdentifier;
+  const publicSubjectId = event.pathParameters?.publicSubjectId;
   const response = getUserScenario(
-    mfaIdentifier ? mfaIdentifier : "default",
+    publicSubjectId ? publicSubjectId : "default",
     "mfaMethods"
   );
   return handleMFAResponse(response);

--- a/template.yaml
+++ b/template.yaml
@@ -999,8 +999,8 @@ Resources:
         userinfo:
           Type: Api
           Properties:
-            Path: /v1/mfa-methods/retrieve
-            Method: POST
+            Path: /v1/mfa-methods/{publicSubjectId}
+            Method: GET
             RestApiId:
               Ref: MethodManagementv1StubsRestApi
       VpcConfig:
@@ -1050,7 +1050,7 @@ Resources:
         userinfo:
           Type: Api
           Properties:
-            Path: /v1/mfa-methods
+            Path: /v1/mfa-methods/{publicSubjectId}
             Method: POST
             RestApiId:
               Ref: MethodManagementv1StubsRestApi
@@ -1101,7 +1101,7 @@ Resources:
         putMfaMethod:
           Type: Api
           Properties:
-            Path: /v1/mfa-methods/{mfaIdentifier}
+            Path: /v1/mfa-methods/{publicSubjectId}
             Method: PUT
             RestApiId:
               Ref: MethodManagementv1StubsRestApi
@@ -1152,7 +1152,7 @@ Resources:
         userinfo:
           Type: Api
           Properties:
-            Path: /v1/mfa-methods/{mfaIdentifier}
+            Path: /v1/mfa-methods/{publicSubjectId}/{mfaIdentifier}
             Method: DELETE
             RestApiId:
               Ref: MethodManagementv1StubsRestApi


### PR DESCRIPTION

## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

Update the URLs in our stubs to match and pick up the new path parameter in the retrieve handler.

We'll also need to update the other methods to use the ID from the path. My plan is to validate this change with the retrieve method, then I'll update the rest in a followup PR.

I've released this branch to dev and verified the frontend does now pick up the user's MFA methods:
![image](https://github.com/user-attachments/assets/62b96609-bc4d-439a-810c-47a08800fa41)


### Why did it change

The URL structure of the API has changed to include the public subject ID in the path, rather than the API inferring it from the auth token.

### Related links

[API spec](https://github.com/govuk-one-login/openapi-specs/blob/main/auth/account-management-api/account-management-with-mfa-method-management.yaml#L69)

## Checklists

<!-- Merging this PR deploys the stubs. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed
