### PR TITLE
OLH-2534: Update remaining method management stubs for the new API spec

### DIFF
--- a/src/method-management/method-management.ts
+++ b/src/method-management/method-management.ts
@@ -2,10 +2,7 @@ import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import assert from "node:assert/strict";
 import { validateFields } from "../common/validation";
 import { formatResponse } from "../common/response-utils";
-import {
-  getUserIdFromEvent,
-  getUserScenario,
-} from "../scenarios/scenarios-utils";
+import { getUserScenario } from "../scenarios/scenarios-utils";
 import { components } from "./models/schema";
 
 export interface Response {
@@ -159,10 +156,10 @@ export const updateMfaMethodHandler = async (
 export const deleteMethodHandler = async (
   event: APIGatewayProxyEvent
 ): Promise<APIGatewayProxyResult> => {
-  const userId = await getUserIdFromEvent(event);
+  const publicSubjectId = event.pathParameters?.publicSubjectId || "default";
   const mfaIdentifier = event.pathParameters?.mfaIdentifier;
 
-  const methods = getUserScenario(userId, "mfaMethods");
+  const methods = getUserScenario(publicSubjectId, "mfaMethods");
   const methodToRemove = methods.find((m) => m.mfaIdentifier == mfaIdentifier);
 
   if (!methodToRemove) {
@@ -173,8 +170,5 @@ export const deleteMethodHandler = async (
     return formatResponse(409, {});
   }
 
-  return formatResponse(
-    200,
-    methods.filter((m) => m.mfaIdentifier != mfaIdentifier)
-  );
+  return formatResponse(204, {});
 };

--- a/src/method-management/method-management.ts
+++ b/src/method-management/method-management.ts
@@ -13,16 +13,6 @@ export interface Response {
   body: string;
 }
 
-export const userInfoHandler = async (
-  event: APIGatewayProxyEvent
-): Promise<Response> => {
-  const response = getUserScenario(
-    await getUserIdFromEvent(event),
-    "mfaMethods"
-  );
-  return handleMFAResponse(response);
-};
-
 function handleMFAResponse(response: components["schemas"]["MfaMethod"][]) {
   if (response.length === 0) {
     // a user with no MFA factors

--- a/src/tests/method-management/method-management.test.ts
+++ b/src/tests/method-management/method-management.test.ts
@@ -5,7 +5,6 @@ import {
 } from "aws-lambda";
 import { components } from "../../method-management/models/schema";
 import {
-  userInfoHandler,
   updateMfaMethodHandler,
   Response,
   createMfaMethodHandler,
@@ -142,39 +141,6 @@ jest.mock("../../scenarios/scenarios-utils.ts", () => {
       }
     }),
   };
-});
-
-describe("MFA Management API Mock", () => {
-  beforeEach(() => {
-    process.env.TABLE_NAME = "table_name";
-  });
-  test("Registered user with a single MFA of type SMS", async () => {
-    const mockApiEvent: APIGatewayProxyEvent = {
-      body: "client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&client_assertion=eyJhbGkpXVCJ9.ey5BPMzRJIn0.RmHvYkaw&grant_type=authorization_code&code=ccca4dec-6799-413c-ab45-896d050006b5&redirect_uri=https%3A%2F%2Fhome.dev.account.gov.uk%2Fauth%2Fcallback",
-      headers: {
-        Authorization:
-          "eyJraWQiOiJCLVFNVXhkSk9KOHVia21BcmM0aTFTR21mWm5OTmxNLXZhOWgwSEowakNvIiwiYWxnIjoiRVMyNTYifQ.eyJzdWIiOiJ1cm46ZmRjOmdvdi51azoyMDIyOjM2MzYxYzY0LTE0NzEtNDllNC1iY2Y0LWRhOTg2MzJlNDc1MyIsImlzcyI6Imh0dHBzOi8vb2lkYy1zdHViLmhvbWUuZGV2LmFjY291bnQuZ292LnVrLyIsImF1ZCI6IlZjZXI3LWl6OUJOcmRWRkctSlZxSjRrMm12dyIsImV4cCI6MTcxNDQ5NDEwOSwiaWF0IjoxNzE0NDkwNTA5LCJzaWQiOiI2MzRjZGE1Ny0zNmQ0LTRjMTEtYTQ2NS0wMTcwNmU2MjNhZTAiLCJub25jZSI6InhQTWtTcFpSbkVrYUdvdXA5MGRCIiwidm90IjoiQ2wuQ20ifQ.bymos9XVETXlHFB53qVhqcalNxUVx5bPCzef1lazthRqkzB-hr7DcIkzd51LEfoBF0MIppLz0vxQajEjgAQMvg",
-      },
-    } as never;
-    // Act
-    const result: Response = await userInfoHandler(mockApiEvent);
-
-    // Assert
-    expect(result).toBeDefined();
-    expect(result.statusCode).toEqual(200);
-    expect(result.body).toBeDefined();
-    const mfaMethod: MfaMethod[] = JSON.parse(result.body);
-    expect(mfaMethod.length).toEqual(1);
-    expect(mfaMethod[0].mfaIdentifier).toEqual("1");
-    expect(mfaMethod[0].priorityIdentifier).toEqual("DEFAULT");
-    expect(mfaMethod[0].method.mfaMethodType).toEqual("SMS");
-    expect(
-      mfaMethod[0].method.mfaMethodType === "SMS"
-        ? mfaMethod[0].method.phoneNumber
-        : false
-    ).toEqual("07123456789");
-    expect(mfaMethod[0].methodVerified).toBe(true);
-  });
 });
 
 describe("retrieveMfaMethodHandler", () => {

--- a/src/tests/method-management/method-management.test.ts
+++ b/src/tests/method-management/method-management.test.ts
@@ -27,21 +27,6 @@ interface Scenario {
 
 jest.mock("../../scenarios/scenarios-utils.ts", () => {
   return {
-    getUserIdFromEvent: jest.fn().mockImplementation((event) => {
-      if (event.headers.Authorization === "errorToken") {
-        return Promise.resolve("errorMfa400");
-      }
-      if (event.headers.Authorization === "reject") {
-        return Promise.reject("MFA Method could not be updated");
-      }
-      if (event.headers.Authorization === "mfaNotFound") {
-        return Promise.resolve("errorMfa404");
-      }
-      if (event.headers.Authorization === "delete") {
-        return Promise.resolve("deleteMethod");
-      }
-      return Promise.resolve("default");
-    }),
     getUserScenario: jest.fn((userId: string, type: string) => {
       const scenarios: Record<string, Scenario> = {
         default: {

--- a/src/tests/method-management/method-management.test.ts
+++ b/src/tests/method-management/method-management.test.ts
@@ -11,7 +11,6 @@ import {
   deleteMethodHandler,
   retrieveMfaMethodHandler,
 } from "../../method-management/method-management";
-import { APIGatewayProxyEventHeaders } from "aws-lambda/trigger/api-gateway-proxy";
 
 type MfaMethod = components["schemas"]["MfaMethod"];
 
@@ -372,13 +371,14 @@ describe("updateMfaMethodHandler", () => {
 describe("deleteMethodHandler", () => {
   const createFakeAPIGatewayProxyEvent = (
     body: unknown,
-    mfaIdentifier: string
+    mfaIdentifier: string,
+    scenario: string
   ): APIGatewayProxyEvent => {
     return {
       body: JSON.stringify(body),
       httpMethod: "DELETE",
-      path: `/mfa-methods/${mfaIdentifier}`,
-      pathParameters: { mfaIdentifier },
+      path: `/mfa-methods/${scenario}/${mfaIdentifier}`,
+      pathParameters: { mfaIdentifier, publicSubjectId: scenario },
       isBase64Encoded: false,
       multiValueHeaders: {},
       queryStringParameters: null,
@@ -393,20 +393,20 @@ describe("deleteMethodHandler", () => {
     };
   };
 
-  test("should delete MFA method correctly", async () => {
-    const fakeEvent = createFakeAPIGatewayProxyEvent({}, "2");
+  test("should delete MFA method and return status 204", async () => {
+    const fakeEvent = createFakeAPIGatewayProxyEvent({}, "2", "deleteMethod");
     const response = await deleteMethodHandler(fakeEvent);
-    expect(response.statusCode).toBe(200);
+    expect(response.statusCode).toBe(204);
   });
 
   test("should 409 if user tries to delete default method", async () => {
-    const fakeEvent = createFakeAPIGatewayProxyEvent({}, "1");
+    const fakeEvent = createFakeAPIGatewayProxyEvent({}, "1", "default");
     const response = await deleteMethodHandler(fakeEvent);
     expect(response.statusCode).toBe(409);
   });
 
   test("should 404 if user tries to delete non existent method", async () => {
-    const fakeEvent = createFakeAPIGatewayProxyEvent({}, "3");
+    const fakeEvent = createFakeAPIGatewayProxyEvent({}, "3", "default");
     const response = await deleteMethodHandler(fakeEvent);
     expect(response.statusCode).toBe(404);
   });

--- a/template.yaml
+++ b/template.yaml
@@ -1094,7 +1094,7 @@ Resources:
         putMfaMethod:
           Type: Api
           Properties:
-            Path: /v1/mfa-methods/{publicSubjectId}
+            Path: /v1/mfa-methods/{publicSubjectId}/{mfaIdentifier}
             Method: PUT
             RestApiId:
               Ref: MethodManagementv1StubsRestApi

--- a/template.yaml
+++ b/template.yaml
@@ -372,6 +372,29 @@ Resources:
       AliasName: !Sub "alias/${AWS::StackName}/${Environment}/DatabaseKmsKey"
       TargetKeyId: !Ref DatabaseKmsKey
 
+  QueryOidcDynamoTablePolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - dynamodb:Query
+              - dynamodb:GetItem
+            Resource:
+              - !GetAtt OidcStubDataStore.Arn
+              - !Sub
+                - "${Arn}/*"
+                - Arn: !GetAtt OidcStubDataStore.Arn
+          - Effect: Allow
+            Action:
+              - kms:Decrypt
+              - kms:GenerateDataKey*
+              - kms:ReEncrypt*
+            Resource:
+              - !GetAtt DatabaseKmsKey.Arn
+
   ######################################
   # OIDC API Stub API Gateway
   ######################################
@@ -945,7 +968,6 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
-        - !Ref QueryOidcDynamoTablePolicy
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -955,29 +977,6 @@ Resources:
                 - lambda.amazonaws.com
             Action:
               - "sts:AssumeRole"
-
-  QueryOidcDynamoTablePolicy:
-    Type: AWS::IAM::ManagedPolicy
-    Properties:
-      PolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Action:
-              - dynamodb:Query
-              - dynamodb:GetItem
-            Resource:
-              - !GetAtt OidcStubDataStore.Arn
-              - !Sub
-                - "${Arn}/*"
-                - Arn: !GetAtt OidcStubDataStore.Arn
-          - Effect: Allow
-            Action:
-              - kms:Decrypt
-              - kms:GenerateDataKey*
-              - kms:ReEncrypt*
-            Resource:
-              - !GetAtt DatabaseKmsKey.Arn
 
   MethodManagementv1ApiStubFunction:
     Type: AWS::Serverless::Function
@@ -1009,9 +1008,6 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
         SecurityGroupIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-AWSServicesEndpointSecurityGroupId
-      Environment:
-        Variables:
-          TABLE_NAME: !Ref OidcStubDataTableName
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -1060,9 +1056,6 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
         SecurityGroupIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-AWSServicesEndpointSecurityGroupId
-      Environment:
-        Variables:
-          TABLE_NAME: !Ref OidcStubDataTableName
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -1111,9 +1104,6 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
         SecurityGroupIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-AWSServicesEndpointSecurityGroupId
-      Environment:
-        Variables:
-          TABLE_NAME: !Ref OidcStubDataTableName
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -1162,9 +1152,6 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
         SecurityGroupIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-AWSServicesEndpointSecurityGroupId
-      Environment:
-        Variables:
-          TABLE_NAME: !Ref OidcStubDataTableName
     Metadata:
       BuildMethod: esbuild
       BuildProperties:


### PR DESCRIPTION
## Proposed changes

### What changed

This is a followup to #444 which updates all the other stub endpoints to the new API spec. 

The updated API design now has the user's public subject ID in the URL for all API methods. This means these stubs no longer need to use the access token to look up which scenario they need to respond with - they now just look it up using the public subject ID. _That_ means I've been able to remove their DynamoDB permissions as well as tidy up the code.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Related links

#444 
[API spec](https://github.com/govuk-one-login/openapi-specs/blob/main/auth/account-management-api/account-management-with-mfa-method-management.yaml) 

## Checklists

<!-- Merging this PR deploys the stubs. Please answer accurately. -->

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed


### Permissions

- [x] This PR adds or changes permissions

## Testing

I've deployed this branch to dev and clicked through a couple of the updated journeys. They all seemed to work ok.

## How to review

There's quite a few changes here, but it should be clear if you review commit by commit.
