### PR TITLE
Fix: update MFA details are nested under mfaMethod

### DIFF
--- a/src/method-management/method-management.ts
+++ b/src/method-management/method-management.ts
@@ -120,7 +120,7 @@ export const updateMfaMethodHandler = async (
   const {
     priorityIdentifier = undefined,
     method: { mfaMethodType = undefined } = {},
-  } = JSON.parse(event.body || "{}");
+  } = JSON.parse(event.body || "{}").mfaMethod ?? {};
 
   const publicSubjectId = event.pathParameters?.publicSubjectId || "default";
   const mfaIdentifier = event.pathParameters?.mfaIdentifier;

--- a/src/tests/method-management/method-management.test.ts
+++ b/src/tests/method-management/method-management.test.ts
@@ -276,10 +276,12 @@ describe("updateMfaMethodHandler", () => {
 
   test("should return 200 and the updated SMS method when the request is valid", async () => {
     const requestBody = {
-      priorityIdentifier: "BACKUP",
-      method: {
-        mfaMethodType: "SMS",
-        phoneNumber: "0123456789",
+      mfaMethod: {
+        priorityIdentifier: "BACKUP",
+        method: {
+          mfaMethodType: "SMS",
+          phoneNumber: "0123456789",
+        },
       },
     };
     const fakeEvent = createFakeAPIGatewayProxyEvent(
@@ -301,10 +303,12 @@ describe("updateMfaMethodHandler", () => {
 
   test("should return 200 and the updated auth app method when the request is valid", async () => {
     const requestBody = {
-      priorityIdentifier: "DEFAULT",
-      method: {
-        mfaMethodType: "AUTH_APP",
-        credential: "aabbccddeeff112233",
+      mfaMethod: {
+        priorityIdentifier: "DEFAULT",
+        method: {
+          mfaMethodType: "AUTH_APP",
+          credential: "aabbccddeeff112233",
+        },
       },
     };
     const fakeEvent = createFakeAPIGatewayProxyEvent(
@@ -326,10 +330,12 @@ describe("updateMfaMethodHandler", () => {
 
   test("should return 400 when the MFA method type is not valid", async () => {
     const requestBody = {
-      priorityIdentifier: "BAD_VALUE",
-      method: {
-        mfaMethodType: "SMS",
-        phoneNumber: "07123456789",
+      mfaMethod: {
+        priorityIdentifier: "BAD_VALUE",
+        method: {
+          mfaMethodType: "SMS",
+          phoneNumber: "07123456789",
+        },
       },
     };
     const fakeEvent = createFakeAPIGatewayProxyEvent(
@@ -343,10 +349,12 @@ describe("updateMfaMethodHandler", () => {
 
   test("should pass through the response code from the scenario", async () => {
     const requestBody = {
-      priorityIdentifier: "BACKUP",
-      method: {
-        mfaMethodType: "SMS",
-        phoneNumber: "07123456789",
+      mfaMethod: {
+        priorityIdentifier: "BACKUP",
+        method: {
+          mfaMethodType: "SMS",
+          phoneNumber: "07123456789",
+        },
       },
     };
     const fakeEvent = createFakeAPIGatewayProxyEvent(


### PR DESCRIPTION
### What changed and why

When parsing the request body for MFA method updating the data is should be extracted from the nested property `mfaMethod` in order to match the OpenAPI spec.

## Checklists

<!-- Merging this PR deploys the stubs. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed
