### PR TITLE
OLH-2592: Don't expect `mfaMethodType` in update requests

### DIFF
--- a/src/method-management/method-management.ts
+++ b/src/method-management/method-management.ts
@@ -98,10 +98,9 @@ export const createMfaMethodHandler = async (
     }
 
     validateFields(
-      { priorityIdentifier, mfaMethodType },
+      { priorityIdentifier },
       {
         priorityIdentifier: /^(DEFAULT|BACKUP)$/,
-        mfaMethodType: /^(AUTH_APP|SMS)$/,
       }
     );
   } catch (e) {


### PR DESCRIPTION


## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

Don't expect `mfaMethodType` in update requests
### Why did it change

Following https://github.com/govuk-one-login/di-account-management-frontend/pull/2170 not every PUT request to the method management API will include an `mfaMethodType` parameter, as this is no longer required when we're switching a method from backup to default.
### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR deploys the stubs. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed
