### PR TITLE
OLH-2627 Account Management Stubs - Create stub scenarios for intervened users

### DIFF
--- a/src/account-management-api/all-routes.ts
+++ b/src/account-management-api/all-routes.ts
@@ -5,10 +5,6 @@ import {
 } from "../scenarios/scenarios-utils";
 import { formatResponse } from "../common/response-utils";
 
-export interface Response {
-  statusCode: number;
-}
-
 export const handler = async (event: APIGatewayProxyEventV2) => {
   if (event?.rawPath.includes("send-otp-notification")) {
     const userId = await getUserIdFromEvent(event);
@@ -17,6 +13,21 @@ export const handler = async (event: APIGatewayProxyEventV2) => {
     const status = scenario.success ? 204 : 400;
 
     return formatResponse(status, scenario);
+  } else if (event?.rawPath.includes("/authenticate")) {
+    const userId = await getUserIdFromEvent(event);
+    const scenario = await getUserScenario(userId, "interventions");
+
+    if (scenario?.blocked) {
+      return formatResponse(403, {
+        code: 1084,
+        message: "User's account is blocked",
+      });
+    } else if (scenario?.suspended) {
+      return formatResponse(403, {
+        code: 1083,
+        message: "User's account is suspended",
+      });
+    }
   }
 
   return {

--- a/src/common/response-utils.ts
+++ b/src/common/response-utils.ts
@@ -1,5 +1,3 @@
-import { Response } from "../method-management/method-management";
-
 export const formatResponse = (
   statusCode: number,
   body: unknown
@@ -7,3 +5,8 @@ export const formatResponse = (
   statusCode,
   body: JSON.stringify(body),
 });
+
+export interface Response {
+  statusCode: number;
+  body: string;
+}

--- a/src/method-management/method-management.ts
+++ b/src/method-management/method-management.ts
@@ -1,14 +1,9 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import assert from "node:assert/strict";
 import { validateFields } from "../common/validation";
-import { formatResponse } from "../common/response-utils";
+import { formatResponse, Response } from "../common/response-utils";
 import { getUserScenario } from "../scenarios/scenarios-utils";
 import { components } from "./models/schema";
-
-export interface Response {
-  statusCode: number;
-  body: string;
-}
 
 function createMfaMethod(
   priorityIdentifier: string,

--- a/src/scenarios/scenarios-utils.ts
+++ b/src/scenarios/scenarios-utils.ts
@@ -67,12 +67,14 @@ export const getUserScenario = <
   const response =
     userScenarios[id][scenario] || userScenarios.default[scenario];
 
-  if ("email" in response) {
-    response.email = `${id}@example.org`;
-  }
+  if (response) {
+    if ("email" in response) {
+      response.email = `${id}@example.org`;
+    }
 
-  if (id === "userPerformanceTest" && "sub" in response) {
-    response.sub = uuidv4();
+    if (id === "userPerformanceTest" && "sub" in response) {
+      response.sub = uuidv4();
+    }
   }
 
   return response;

--- a/src/scenarios/scenarios.interfaces.ts
+++ b/src/scenarios/scenarios.interfaces.ts
@@ -22,6 +22,7 @@ export interface UserScenarios {
     };
     mfaMethods: mfaMethodComponents["schemas"]["MfaMethod"][];
     otpNotification: { success: true } | { success: false; code: number };
+    interventions?: { suspended: boolean; blocked: boolean };
   };
   [key: string]: Partial<UserScenarios["default"]>;
 }

--- a/src/scenarios/scenarios.ts
+++ b/src/scenarios/scenarios.ts
@@ -459,4 +459,100 @@ export const userScenarios: UserScenarios = {
       success: true,
     },
   },
+  permanentlySuspended: {
+    httpResponse: {
+      code: 200,
+      message: "OK",
+    },
+    userinfo: {
+      sub: "urn:fdc:gov.uk:default",
+      email: "your.name@example.com",
+      email_verified: true,
+      phone_number: "1234567890",
+      phone_number_verified: true,
+      public_subject_id: "default",
+    },
+    mfaMethods: [
+      {
+        mfaIdentifier: "0",
+        priorityIdentifier: "DEFAULT",
+        method: {
+          mfaMethodType: "SMS",
+          phoneNumber: "07123456789",
+        },
+        methodVerified: true,
+      },
+    ],
+    otpNotification: {
+      success: true,
+    },
+    interventions: {
+      suspended: true,
+      blocked: false,
+    },
+  },
+  temporarilySuspended: {
+    httpResponse: {
+      code: 200,
+      message: "OK",
+    },
+    userinfo: {
+      sub: "urn:fdc:gov.uk:default",
+      email: "your.name@example.com",
+      email_verified: true,
+      phone_number: "1234567890",
+      phone_number_verified: true,
+      public_subject_id: "default",
+    },
+    mfaMethods: [
+      {
+        mfaIdentifier: "0",
+        priorityIdentifier: "DEFAULT",
+        method: {
+          mfaMethodType: "SMS",
+          phoneNumber: "07123456789",
+        },
+        methodVerified: true,
+      },
+    ],
+    otpNotification: {
+      success: true,
+    },
+    interventions: {
+      suspended: true,
+      blocked: false,
+    },
+  },
+  suspendedAndBlocked: {
+    httpResponse: {
+      code: 200,
+      message: "OK",
+    },
+    userinfo: {
+      sub: "urn:fdc:gov.uk:default",
+      email: "your.name@example.com",
+      email_verified: true,
+      phone_number: "1234567890",
+      phone_number_verified: true,
+      public_subject_id: "default",
+    },
+    mfaMethods: [
+      {
+        mfaIdentifier: "0",
+        priorityIdentifier: "DEFAULT",
+        method: {
+          mfaMethodType: "SMS",
+          phoneNumber: "07123456789",
+        },
+        methodVerified: true,
+      },
+    ],
+    otpNotification: {
+      success: true,
+    },
+    interventions: {
+      suspended: true,
+      blocked: true,
+    },
+  },
 };

--- a/src/tests/method-management/method-management.test.ts
+++ b/src/tests/method-management/method-management.test.ts
@@ -6,11 +6,11 @@ import {
 import { components } from "../../method-management/models/schema";
 import {
   updateMfaMethodHandler,
-  Response,
   createMfaMethodHandler,
   deleteMethodHandler,
   retrieveMfaMethodHandler,
 } from "../../method-management/method-management";
+import { Response } from "../../common/response-utils";
 
 type MfaMethod = components["schemas"]["MfaMethod"];
 


### PR DESCRIPTION
## Proposed changes

OLH-2627 Account Management Stubs - Create stub scenarios for intervened users

### What changed

Update the stubs to handle incoming request to authenticate endpoint to ensure  accounts with suspended or blocked interventions returns an appropriate response

### Why did it change

Support the AIS Data Integrity initiative

### Related links

https://govukverify.atlassian.net/browse/OLH-2627

## Checklists

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Permissions

## Testing
Deploy the stub to dev environment and ensure all existing functionality still works. Implementation of these changes will be done as part of https://govukverify.atlassian.net/browse/OLH-2626

## How to review
