### PR TITLE
OLH-2655: Handle OIDC logout requests

### DIFF
--- a/docs/oidc/openapi.yaml
+++ b/docs/oidc/openapi.yaml
@@ -116,6 +116,39 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/UserInfo"
+  /logout:
+    get:
+      description: |-
+        Log the user out and return them to either the supplied redirect URI or a default one if none is provided.
+        Requires at least one of an `Origin` or `Referer` header to validate the calling app and construct the default return URL.
+      parameters:
+        - in: query
+          name: id_token_hint
+          schema:
+            type: string
+          required: false
+          description: The user's ID token.
+        - in: query
+          name: post_logout_redirect_uri
+          schema:
+            type: string
+          required: false
+          description: The URI to redirect the user back to after logout. If provided, id_token_hint must also be present.
+        - in: header
+          name: Origin
+          schema:
+            type: string
+          required: false
+        - in: header
+          name: Referer
+          schema:
+            type: string
+          required: false
+
+      responses:
+        "302":
+          description: |-
+            After a successful logout, return the user to either the supplied redirect URI or the default.
 
 components:
   schemas:

--- a/docs/oidc/openapi.yaml
+++ b/docs/oidc/openapi.yaml
@@ -121,6 +121,7 @@ paths:
       description: |-
         Log the user out and return them to either the supplied redirect URI or a default one if none is provided.
         Requires at least one of an `Origin` or `Referer` header to validate the calling app and construct the default return URL.
+        If `state` query parameter is passed, the value is appended to the redirect URL.
       parameters:
         - in: query
           name: id_token_hint
@@ -134,6 +135,11 @@ paths:
             type: string
           required: false
           description: The URI to redirect the user back to after logout. If provided, id_token_hint must also be present.
+        - in: query
+          name: state
+          schema:
+            type: string
+          required: false
         - in: header
           name: Origin
           schema:

--- a/src/common/response-utils.ts
+++ b/src/common/response-utils.ts
@@ -10,3 +10,10 @@ export interface Response {
   statusCode: number;
   body: string;
 }
+
+export interface RedirectResponse {
+  statusCode: 302;
+  headers: {
+    Location: string;
+  };
+}

--- a/src/common/validation.ts
+++ b/src/common/validation.ts
@@ -15,3 +15,14 @@ export const validateFields = (
     }
   });
 };
+
+export const validateSameHostname = (firstUri: string, secondUri: string) => {
+  const first = new URL(firstUri);
+  const second = new URL(secondUri);
+
+  if (first.hostname != second.hostname) {
+    throw new Error(
+      `Hostnames ${first.hostname} and ${second.hostname} do not match`
+    );
+  }
+};

--- a/src/oidc/configuration.ts
+++ b/src/oidc/configuration.ts
@@ -32,7 +32,7 @@ export const handler = async () => {
     trustmarks: "https://unsuported-by-stub.gov.uk/",
     subject_types_supported: ["public", "pairwise"],
     userinfo_endpoint: `https://oidc-stub.home.${ENVIRONMENT}.account.gov.uk/userinfo`,
-    end_session_endpoint: "https://signin.build.account.gov.uk/signed-out",
+    end_session_endpoint: `https://oidc-stub.home.${ENVIRONMENT}.account.gov.uk/logout`,
     id_token_signing_alg_values_supported: ["ES256", "RS256"],
     claim_types_supported: ["normal"],
     claims_supported: [

--- a/src/oidc/logout.ts
+++ b/src/oidc/logout.ts
@@ -1,0 +1,54 @@
+import { APIGatewayProxyEvent } from "aws-lambda";
+import { RedirectResponse } from "../common/response-utils";
+import assert from "node:assert/strict";
+
+const VALID_HOSTNAMES = [
+  "home.dev.account.gov.uk",
+  "home.build.account.gov.uk",
+  "localhost",
+];
+
+export const validateRedirectUri = (redirectUri: string) => {
+  const url = new URL(redirectUri);
+  if (!VALID_HOSTNAMES.includes(url.hostname)) {
+    throw new Error("Redirect URI must be to an allowed domain");
+  }
+
+  if (url.hostname === "localhost" && url.protocol === "http:") {
+    return;
+  }
+
+  if (url.protocol != "https:") {
+    throw new Error("Redirect URI protocol must be HTTPS if not localhost");
+  }
+};
+
+export const validateReferrer = (referrer: string) => {
+  const url = new URL(referrer);
+  if (!VALID_HOSTNAMES.includes(url.hostname)) {
+    throw new Error("Referrer must be an allowed domain");
+  }
+};
+
+export const handler = async (
+  event: APIGatewayProxyEvent
+): Promise<RedirectResponse> => {
+  assert(event.queryStringParameters, "No query parameters provided");
+
+  const token = event.queryStringParameters.id_token_hint;
+  const redirectUri = event.queryStringParameters.post_logout_redirect_uri;
+  const referrer = event.headers.Referer;
+
+  assert(token, "No id_token_hint provided");
+  assert(redirectUri, "No post_logout_redirect_uri provided");
+  assert(referrer, "No Origin header");
+
+  validateRedirectUri(redirectUri);
+  validateReferrer(referrer);
+  return {
+    statusCode: 302,
+    headers: {
+      Location: redirectUri,
+    },
+  };
+};

--- a/src/oidc/logout.ts
+++ b/src/oidc/logout.ts
@@ -1,6 +1,7 @@
 import { APIGatewayProxyEvent } from "aws-lambda";
 import { RedirectResponse } from "../common/response-utils";
 import assert from "node:assert/strict";
+import { validateSameHostname } from "../common/validation";
 
 const VALID_HOSTNAMES = [
   "home.dev.account.gov.uk",
@@ -43,8 +44,10 @@ export const handler = async (
   assert(redirectUri, "No post_logout_redirect_uri provided");
   assert(referrer, "No Origin header");
 
-  validateRedirectUri(redirectUri);
   validateReferrer(referrer);
+
+  validateRedirectUri(redirectUri);
+  validateSameHostname(redirectUri, referrer);
   return {
     statusCode: 302,
     headers: {

--- a/src/oidc/logout.ts
+++ b/src/oidc/logout.ts
@@ -75,6 +75,7 @@ export const handler = async (
 ): Promise<RedirectResponse> => {
   const token = event.queryStringParameters?.id_token_hint;
   let redirectUri = event.queryStringParameters?.post_logout_redirect_uri;
+  const state = event.queryStringParameters?.state;
   const referrer = event.headers.Referer;
   const origin = event.headers.Origin;
 
@@ -97,6 +98,12 @@ export const handler = async (
   }
   if (origin) {
     validateSameHostname(redirectUri, origin);
+  }
+
+  if (state) {
+    const url = new URL(redirectUri);
+    url.searchParams.append("state", state);
+    redirectUri = url.href;
   }
 
   return {

--- a/src/tests/common/validation.test.ts
+++ b/src/tests/common/validation.test.ts
@@ -1,4 +1,4 @@
-import { validateFields } from "../../common/validation";
+import { validateFields, validateSameHostname } from "../../common/validation";
 
 describe("validateFields Function", () => {
   it("should validate required fields successfully", () => {
@@ -56,5 +56,29 @@ describe("validateFields Function", () => {
     expect(() => validateFields(fields, checks)).toThrow(
       /invalid mfaIdentifier/
     );
+  });
+});
+
+describe(validateSameHostname, () => {
+  test("it throws an error if either URI is malformed", () => {
+    expect(() => {
+      validateSameHostname("Not a URI", "http://example.com");
+    }).toThrow();
+
+    expect(() => {
+      validateSameHostname("http://example.com", "Not a URI");
+    }).toThrow();
+  });
+
+  test("it throws an error if the hostnames don't match", () => {
+    expect(() => {
+      validateSameHostname("http://not-example.com", "http://example.com");
+    }).toThrow();
+  });
+
+  test("it doesn't throw an error when the hostnames match", () => {
+    expect(() => {
+      validateSameHostname("http://example.com", "http://example.com");
+    }).not.toThrow();
   });
 });

--- a/src/tests/oidc/logout.test.ts
+++ b/src/tests/oidc/logout.test.ts
@@ -172,8 +172,22 @@ describe(handler, () => {
     };
     const response = await handler(event as APIGatewayProxyEvent);
     expect(response.statusCode).toBe(302);
+    expect(response.headers.Location).toBe(EXPECTED_INFERRED_REDIRECT_URI);
+  });
+
+  test("appends the state parameter to the redirect URL if provided", async () => {
+    const event: Partial<APIGatewayProxyEvent> = {
+      queryStringParameters: {
+        state: "stateValue",
+      },
+      headers: {
+        Origin: VALID_REDIRECT_OR_HEADER_URI,
+      },
+    };
+    const response = await handler(event as APIGatewayProxyEvent);
+    expect(response.statusCode).toBe(302);
     expect(response.headers.Location).toBe(
-      "https://home.dev.account.gov.uk/logout-return"
+      `${EXPECTED_INFERRED_REDIRECT_URI}?state=stateValue`
     );
   });
 

--- a/src/tests/oidc/logout.test.ts
+++ b/src/tests/oidc/logout.test.ts
@@ -1,0 +1,143 @@
+import {
+  handler,
+  validateRedirectUri,
+  validateReferrer,
+} from "../../oidc/logout";
+import { APIGatewayProxyEvent } from "aws-lambda";
+
+const VALID_REDIRECT_URI = "https://home.dev.account.gov.uk/logout";
+
+describe(validateRedirectUri, () => {
+  test("throws an error with a malformed URI", () => {
+    expect(() => {
+      validateRedirectUri("Not a URL");
+    }).toThrow();
+  });
+
+  test("throws an error when the domain is not allowed", () => {
+    expect(() => {
+      validateRedirectUri("https://example.com/logout");
+    }).toThrow();
+  });
+
+  test("throws an error when domain is valid but not HTTPS", () => {
+    expect(() => {
+      validateRedirectUri("http://home.dev.account.gov.uk/logout");
+    }).toThrow();
+  });
+
+  test("doesn't throw an error when redirecting to localhost on HTTP", () => {
+    expect(() => {
+      validateRedirectUri("http://localhost/logout");
+    }).not.toThrow();
+  });
+
+  test("doesn't throw an error when redirecting to a valid domain on https", () => {
+    expect(() => {
+      validateRedirectUri(VALID_REDIRECT_URI);
+    }).not.toThrow();
+  });
+});
+
+describe(validateReferrer, () => {
+  test("throws an error with a malformed URI", () => {
+    expect(() => {
+      validateReferrer("Not a URL");
+    }).toThrow();
+  });
+
+  test("throws an error when the domain is not allowed", () => {
+    expect(() => {
+      validateReferrer("https://example.com/logout");
+    }).toThrow();
+  });
+
+  test("doesn't throw an error when referrer is localhost", () => {
+    expect(() => {
+      validateReferrer("http://localhost/logout");
+    }).not.toThrow();
+  });
+
+  test("doesn't throw an error when redirecting to a valid domain on https", () => {
+    expect(() => {
+      validateReferrer(VALID_REDIRECT_URI);
+    }).not.toThrow();
+  });
+});
+
+describe(handler, () => {
+  test("returns a redirect response from a valid request", async () => {
+    const event: Partial<APIGatewayProxyEvent> = {
+      queryStringParameters: {
+        post_logout_redirect_uri: VALID_REDIRECT_URI,
+        id_token_hint: "id-token",
+      },
+      headers: {
+        Referer: VALID_REDIRECT_URI,
+      },
+    };
+    const response = await handler(event as APIGatewayProxyEvent);
+    expect(response.statusCode).toBe(302);
+    expect(response.headers.Location).toBe(VALID_REDIRECT_URI);
+  });
+
+  test("throws an error when ID token is missing", async () => {
+    const event: Partial<APIGatewayProxyEvent> = {
+      queryStringParameters: {
+        post_logout_redirect_uri: VALID_REDIRECT_URI,
+      },
+      headers: {
+        Referer: VALID_REDIRECT_URI,
+      },
+    };
+    expect(handler(event as APIGatewayProxyEvent)).rejects.toThrow();
+  });
+
+  test("throws an error when redirect URI is missing", async () => {
+    const event: Partial<APIGatewayProxyEvent> = {
+      queryStringParameters: {
+        id_token_hint: "id-token",
+      },
+      headers: {
+        Referer: VALID_REDIRECT_URI,
+      },
+    };
+    expect(handler(event as APIGatewayProxyEvent)).rejects.toThrow();
+  });
+
+  test("throws an error when redirect URI is not on the allow list", async () => {
+    const event: Partial<APIGatewayProxyEvent> = {
+      queryStringParameters: {
+        post_logout_redirect_uri: "https://example.com/logout",
+        id_token_hint: "id-token",
+      },
+      headers: {
+        Referer: VALID_REDIRECT_URI,
+      },
+    };
+    expect(handler(event as APIGatewayProxyEvent)).rejects.toThrow();
+  });
+
+  test("throws an error when referrer header is missing", async () => {
+    const event: Partial<APIGatewayProxyEvent> = {
+      queryStringParameters: {
+        post_logout_redirect_uri: VALID_REDIRECT_URI,
+        id_token_hint: "id-token",
+      },
+    };
+    expect(handler(event as APIGatewayProxyEvent)).rejects.toThrow();
+  });
+
+  test("throws an error when referrer is not on the allow list", async () => {
+    const event: Partial<APIGatewayProxyEvent> = {
+      queryStringParameters: {
+        post_logout_redirect_uri: VALID_REDIRECT_URI,
+        id_token_hint: "id-token",
+      },
+      headers: {
+        Referer: "https://example.com/logout",
+      },
+    };
+    expect(handler(event as APIGatewayProxyEvent)).rejects.toThrow();
+  });
+});

--- a/src/tests/oidc/logout.test.ts
+++ b/src/tests/oidc/logout.test.ts
@@ -140,4 +140,17 @@ describe(handler, () => {
     };
     expect(handler(event as APIGatewayProxyEvent)).rejects.toThrow();
   });
+
+  test("throws an error when referrer and redirect domains don't match", async () => {
+    const event: Partial<APIGatewayProxyEvent> = {
+      queryStringParameters: {
+        post_logout_redirect_uri: VALID_REDIRECT_URI,
+        id_token_hint: "id-token",
+      },
+      headers: {
+        Referer: "http://localhost/logout",
+      },
+    };
+    expect(handler(event as APIGatewayProxyEvent)).rejects.toThrow();
+  });
 });

--- a/template.yaml
+++ b/template.yaml
@@ -886,6 +886,77 @@ Resources:
       RetentionInDays: 30
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
+  ######################################
+  # OIDC Token API Stub
+  ######################################
+  OidcLogoutApiStubFunction:
+    Type: AWS::Serverless::Function
+    # checkov:skip=CKV_AWS_116
+    DependsOn:
+      - OidcLogoutApiStubFunctionLogGroup
+    Properties:
+      FunctionName: !Sub ${Environment}-${AWS::StackName}-oidc-logout
+      Architectures: ["arm64"]
+      CodeUri: src/oidc
+      Handler: logout.handler
+      KmsKeyArn: !GetAtt LambdaKMSKey.Arn
+      PackageType: Zip
+      MemorySize: 256
+      ReservedConcurrentExecutions: 30
+      Role: !GetAtt OidcLogoutApiStubFunctionRole.Arn
+      Timeout: 5
+      Events:
+        logout:
+          Type: Api
+          Properties:
+            Path: /logout
+            Method: GET
+            RestApiId:
+              Ref: OidcStubsRestApi
+      VpcConfig:
+        SubnetIds:
+          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
+          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
+        SecurityGroupIds:
+          - Fn::ImportValue: !Sub ${VpcStackName}-AWSServicesEndpointSecurityGroupId
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        Minify: true
+        Target: "es2020"
+        Sourcemap: true
+        EntryPoints:
+          - logout.ts
+
+  OidcLogoutApiStubFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - "sts:AssumeRole"
+
+  OidcLogoutApiStubFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${Environment}-${AWS::StackName}-oidc-logout"
+      RetentionInDays: 30
+      KmsKeyId: !GetAtt LoggingKmsKey.Arn
+
   #
   # Method Management
   #

--- a/template.yaml
+++ b/template.yaml
@@ -905,6 +905,9 @@ Resources:
       ReservedConcurrentExecutions: 30
       Role: !GetAtt OidcLogoutApiStubFunctionRole.Arn
       Timeout: 5
+      Environment:
+        Variables:
+          ENVIRONMENT: !Ref Environment
       Events:
         logout:
           Type: Api

--- a/template.yaml
+++ b/template.yaml
@@ -887,7 +887,7 @@ Resources:
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   ######################################
-  # OIDC Token API Stub
+  # OIDC Logout API Stub
   ######################################
   OidcLogoutApiStubFunction:
     Type: AWS::Serverless::Function
@@ -897,7 +897,7 @@ Resources:
     Properties:
       FunctionName: !Sub ${Environment}-${AWS::StackName}-oidc-logout
       Architectures: ["arm64"]
-      CodeUri: src/oidc
+      CodeUri: src
       Handler: logout.handler
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
@@ -926,7 +926,7 @@ Resources:
         Target: "es2020"
         Sourcemap: true
         EntryPoints:
-          - logout.ts
+          - oidc/logout.ts
 
   OidcLogoutApiStubFunctionRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION

## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

'Handle' OIDC logout requests that include a `post_logout_redirect_uri` parameter by validating the domain and simply redirecting the user back to that URI. This adds a new Lambda and API Gateway route that's published in the OIDC configuration.

This is compliant with the logout interface described in [our public tech documentation](https://docs.sign-in.service.gov.uk/integrate-with-integration-environment/managing-your-users-sessions/#make-a-request-to-log-your-user-out-of-gov-uk-one-login).

We need to do the domain validation here to protect ourselves from an [open redirect attack](https://hacksplaining.com/prevention/open-redirects). We need to be extra carfeul here as we allow redirects to `localhost`. If an attacker's got a webserver running on a user's machine then that user is already having a bad day. We need to do as much as we can to prevent phishing links off the `*.gov.uk` domain which is why I've also added the referrer check.

### Why did it change

So we have realistic behaviour when logging out in our local, dev and pre-production environments.

## Checklists

<!-- Merging this PR deploys the stubs. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed
