### PR TITLE
OLH-2683: change logout logic to better reflect what happens in the r…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "@types/aws-lambda": "^8.10.149",
         "dotenv": "^16.5.0",
         "jose": "^5.9.6",
-        "uuid": "^11.1.0"
+        "uuid": "^11.1.0",
+        "valibot": "^1.1.0"
       },
       "devDependencies": {
         "@babel/core": "^7.27.1",
@@ -11544,7 +11545,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -11707,6 +11708,20 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/valibot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.1.0.tgz",
+      "integrity": "sha512-Nk8lX30Qhu+9txPYTwM0cFlWLdPFsFr6LblzqIySfbZph9+BFsAHsNvHOymEviUepeIW6KFHzpX8TKhbptBXXw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "@types/aws-lambda": "^8.10.149",
     "dotenv": "^16.5.0",
     "jose": "^5.9.6",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "valibot": "^1.1.0"
   },
   "lint-staged": {
     "**/*.{js,jsx,ts,tsx,json,css,scss,md,yaml}": [

--- a/src/common/validation.ts
+++ b/src/common/validation.ts
@@ -15,14 +15,3 @@ export const validateFields = (
     }
   });
 };
-
-export const validateSameHostname = (firstUri: string, secondUri: string) => {
-  const first = new URL(firstUri);
-  const second = new URL(secondUri);
-
-  if (first.hostname != second.hostname) {
-    throw new Error(
-      `Hostnames ${first.hostname} and ${second.hostname} do not match`
-    );
-  }
-};

--- a/src/oidc/logout.ts
+++ b/src/oidc/logout.ts
@@ -5,13 +5,13 @@ import * as v from "valibot";
 export const validateRedirectUri = (rawRedirectUri: string) => {
   const redirectUri = v.parse(v.pipe(v.string(), v.url()), rawRedirectUri);
 
-  const rawLogoutRedirectUrisConfiguredForRp = JSON.parse(
+  const rawPostLogoutRedirectUrisConfiguredForRp = JSON.parse(
     process.env.POST_LOGOUT_REDIRECT_URIS ?? "[]"
   );
 
   const postLogoutRedirectUrisConfiguredForRp = v.parse(
     v.pipe(v.array(v.pipe(v.string(), v.url())), v.minLength(1)),
-    rawLogoutRedirectUrisConfiguredForRp
+    rawPostLogoutRedirectUrisConfiguredForRp
   );
 
   for (const postLogoutRedirectUriConfiguredForRp of postLogoutRedirectUrisConfiguredForRp) {

--- a/src/oidc/logout.ts
+++ b/src/oidc/logout.ts
@@ -1,48 +1,28 @@
 import { APIGatewayProxyEvent } from "aws-lambda";
 import { RedirectResponse } from "../common/response-utils";
-import { validateSameHostname } from "../common/validation";
+import * as v from "valibot";
 
-export const validateHostname = (host: string) => {
-  // Domain is localhost OR ends in .account.gov.uk
-  if (!host.match(/(?:.+\.account\.gov\.uk$)|^localhost$/)) {
-    throw new Error(`Hostname ${host} is not allowed`);
-  }
-};
+export const validateRedirectUri = (rawRedirectUri: string) => {
+  const redirectUri = v.parse(v.pipe(v.string(), v.url()), rawRedirectUri);
 
-export const validateRedirectUri = (redirectUri: string) => {
-  const url = new URL(redirectUri);
-  validateHostname(url.hostname);
+  const rawLogoutRedirectUrisConfiguredForRp = JSON.parse(
+    process.env.POST_LOGOUT_REDIRECT_URIS ?? "[]"
+  );
 
-  if (url.hostname === "localhost" && url.protocol === "http:") {
-    return;
-  }
+  const postLogoutRedirectUrisConfiguredForRp = v.parse(
+    v.pipe(v.array(v.pipe(v.string(), v.url())), v.minLength(1)),
+    rawLogoutRedirectUrisConfiguredForRp
+  );
 
-  if (url.protocol != "https:") {
-    throw new Error("Redirect URI protocol must be HTTPS if not localhost");
-  }
-};
-
-export const validateReferrerAndOrigin = (
-  referrerUri: string | undefined,
-  originUri: string | undefined
-) => {
-  if (!referrerUri && !originUri) {
-    throw new Error("Must provide at least one of Origin or Referer headers");
+  for (const postLogoutRedirectUriConfiguredForRp of postLogoutRedirectUrisConfiguredForRp) {
+    if (redirectUri === postLogoutRedirectUriConfiguredForRp) {
+      return;
+    }
   }
 
-  if (referrerUri) {
-    const referrer = new URL(referrerUri);
-    validateHostname(referrer.hostname);
-  }
-
-  if (originUri) {
-    const origin = new URL(originUri);
-    validateHostname(origin.hostname);
-  }
-
-  if (referrerUri && originUri) {
-    validateSameHostname(referrerUri, originUri);
-  }
+  throw new Error(
+    `Redirect URI must match one of the post logout redirect URIs configured for this RP: ${process.env.POST_LOGOUT_REDIRECT_URIS}`
+  );
 };
 
 const buildDefaultRedirectUri = (): string => {
@@ -55,36 +35,20 @@ export const handler = async (
   const token = event.queryStringParameters?.id_token_hint;
   let redirectUri = event.queryStringParameters?.post_logout_redirect_uri;
   const state = event.queryStringParameters?.state;
-  const referrer = event.headers.Referer;
-  const origin = event.headers.Origin;
 
-  validateReferrerAndOrigin(referrer, origin);
-
-  if (redirectUri) {
-    if (referrer) {
-      validateSameHostname(redirectUri, referrer);
-    }
-    if (origin) {
-      validateSameHostname(redirectUri, origin);
-    }
-  }
-
-  if (!redirectUri || !token) {
-    if (!redirectUri && !token) {
+  if (redirectUri && token) {
+    try {
+      validateRedirectUri(redirectUri);
+      const uri = new URL(redirectUri);
+      if (state) {
+        uri.searchParams.append("state", state);
+      }
+      redirectUri = uri.href;
+    } catch {
       redirectUri = buildDefaultRedirectUri();
-    } else {
-      throw new Error(
-        "Must provide both id_token_hint and post_logout_redirect_uri or neither"
-      );
     }
-  }
-
-  validateRedirectUri(redirectUri);
-
-  if (state) {
-    const url = new URL(redirectUri);
-    url.searchParams.append("state", state);
-    redirectUri = url.href;
+  } else {
+    redirectUri = buildDefaultRedirectUri();
   }
 
   return {

--- a/src/tests/common/validation.test.ts
+++ b/src/tests/common/validation.test.ts
@@ -1,4 +1,4 @@
-import { validateFields, validateSameHostname } from "../../common/validation";
+import { validateFields } from "../../common/validation";
 
 describe("validateFields Function", () => {
   it("should validate required fields successfully", () => {
@@ -56,29 +56,5 @@ describe("validateFields Function", () => {
     expect(() => validateFields(fields, checks)).toThrow(
       /invalid mfaIdentifier/
     );
-  });
-});
-
-describe(validateSameHostname, () => {
-  test("it throws an error if either URI is malformed", () => {
-    expect(() => {
-      validateSameHostname("Not a URI", "http://example.com");
-    }).toThrow();
-
-    expect(() => {
-      validateSameHostname("http://example.com", "Not a URI");
-    }).toThrow();
-  });
-
-  test("it throws an error if the hostnames don't match", () => {
-    expect(() => {
-      validateSameHostname("http://not-example.com", "http://example.com");
-    }).toThrow();
-  });
-
-  test("it doesn't throw an error when the hostnames match", () => {
-    expect(() => {
-      validateSameHostname("http://example.com", "http://example.com");
-    }).not.toThrow();
   });
 });

--- a/src/tests/oidc/logout.test.ts
+++ b/src/tests/oidc/logout.test.ts
@@ -1,316 +1,151 @@
-import {
-  handler,
-  validateRedirectUri,
-  validateReferrerAndOrigin,
-  validateHostname,
-} from "../../oidc/logout";
+import { handler, validateRedirectUri } from "../../oidc/logout";
 import { APIGatewayProxyEvent } from "aws-lambda";
 
-const VALID_REDIRECT_OR_HEADER_URI = "https://home.dev.account.gov.uk/logout";
-const EXPECTED_INFERRED_REDIRECT_URI =
-  "https://signin.test.account.gov.uk/signed-out";
-
 describe(validateRedirectUri, () => {
-  test("throws an error with a malformed URI", () => {
+  test("throws an error when an invalid URI is passed in", () => {
     expect(() => {
       validateRedirectUri("Not a URL");
     }).toThrow();
   });
 
-  test("throws an error when the domain is not allowed", () => {
+  test("throws an error when process.env.POST_LOGOUT_REDIRECT_URIS is undefined", () => {
     expect(() => {
       validateRedirectUri("https://example.com/logout");
     }).toThrow();
   });
 
-  test("throws an error when domain is valid but not HTTPS", () => {
+  test("throws an error when process.env.POST_LOGOUT_REDIRECT_URIS is not an array", () => {
     expect(() => {
-      validateRedirectUri("http://home.dev.account.gov.uk/logout");
+      process.env.POST_LOGOUT_REDIRECT_URIS = JSON.stringify("Not an array");
+      validateRedirectUri("https://example.com/logout");
     }).toThrow();
   });
 
-  test("doesn't throw an error when redirecting to localhost on HTTP", () => {
+  test("throws an error when process.env.POST_LOGOUT_REDIRECT_URIS is an empty array", () => {
     expect(() => {
-      validateRedirectUri("http://localhost/logout");
+      process.env.POST_LOGOUT_REDIRECT_URIS = JSON.stringify([]);
+      validateRedirectUri("https://example.com/logout");
+    }).toThrow();
+  });
+
+  test("throws an error when process.env.POST_LOGOUT_REDIRECT_URIS contains invalid URIs", () => {
+    expect(() => {
+      process.env.POST_LOGOUT_REDIRECT_URIS = JSON.stringify([
+        "https://example.com/logout",
+        "Not a URL",
+      ]);
+      validateRedirectUri("https://example.com/logout");
+    }).toThrow();
+  });
+
+  test("throws an error when the passed in URI does not match any of the POST_LOGOUT_REDIRECT_URIS", () => {
+    expect(() => {
+      process.env.POST_LOGOUT_REDIRECT_URIS = JSON.stringify([
+        "https://example1.com/logout",
+        "https://example.com/login",
+        "http://example.com/logout",
+      ]);
+      validateRedirectUri("https://example.com/logout");
+    }).toThrow();
+  });
+
+  test("doesn't throw an error when the passed in URI does match some of the POST_LOGOUT_REDIRECT_URIS", () => {
+    expect(() => {
+      process.env.POST_LOGOUT_REDIRECT_URIS = JSON.stringify([
+        "https://example1.com/logout",
+        "https://example.com/login",
+        "https://example.com/logout",
+      ]);
+      validateRedirectUri("https://example.com/logout");
     }).not.toThrow();
-  });
-
-  test("doesn't throw an error when redirecting to a valid domain on https", () => {
-    expect(() => {
-      validateRedirectUri(VALID_REDIRECT_OR_HEADER_URI);
-    }).not.toThrow();
-  });
-});
-
-describe(validateReferrerAndOrigin, () => {
-  test("throws an error if either parameter is malformed", () => {
-    expect(() => {
-      validateReferrerAndOrigin("Not a URL", VALID_REDIRECT_OR_HEADER_URI);
-    }).toThrow();
-
-    expect(() => {
-      validateReferrerAndOrigin(VALID_REDIRECT_OR_HEADER_URI, "Not a URL");
-    }).toThrow();
-  });
-
-  test("throws an error if either URI isn't on the allow list", () => {
-    expect(() => {
-      validateReferrerAndOrigin(
-        "http://example.com",
-        VALID_REDIRECT_OR_HEADER_URI
-      );
-    }).toThrow();
-
-    expect(() => {
-      validateReferrerAndOrigin(
-        VALID_REDIRECT_OR_HEADER_URI,
-        "http://example.com"
-      );
-    }).toThrow();
-  });
-
-  test("throws an error if both parameters are undefined", () => {
-    expect(() => {
-      validateReferrerAndOrigin(undefined, undefined);
-    }).toThrow();
-  });
-
-  test("throws an error when the domains don't match", () => {
-    expect(() => {
-      validateReferrerAndOrigin(
-        VALID_REDIRECT_OR_HEADER_URI,
-        "https://home.build.account.gov.uk/logout"
-      );
-    }).toThrow();
-  });
-
-  test("doesn't throw an error when only a valid referrer is passed ", () => {
-    expect(() => {
-      validateReferrerAndOrigin(VALID_REDIRECT_OR_HEADER_URI, undefined);
-    }).not.toThrow();
-  });
-
-  test("doesn't throw an error when only a valid origin is passed ", () => {
-    expect(() => {
-      validateReferrerAndOrigin(undefined, VALID_REDIRECT_OR_HEADER_URI);
-    }).not.toThrow();
-  });
-
-  test("doesn't throw an error when both valid referrer and origin is passed ", () => {
-    expect(() => {
-      validateReferrerAndOrigin(
-        VALID_REDIRECT_OR_HEADER_URI,
-        VALID_REDIRECT_OR_HEADER_URI
-      );
-    }).not.toThrow();
-  });
-});
-
-describe(validateHostname, () => {
-  test("doesn't throw an error with localhost", () => {
-    expect(() => {
-      validateHostname("localhost");
-    }).not.toThrow();
-  });
-
-  test("doesn't throw an error with our dev domain", () => {
-    expect(() => {
-      validateHostname("home.dev.account.gov.uk");
-    }).not.toThrow();
-  });
-
-  test("doesn't throw an error with Auths dev domain", () => {
-    expect(() => {
-      validateHostname("signin.dev.account.gov.uk");
-    }).not.toThrow();
-  });
-
-  test("throws an error when the hostname is not allowed", () => {
-    expect(() => {
-      validateHostname("example.com");
-    }).toThrow();
-  });
-
-  test("throws an error when the hostname is another GOV.UK domain", () => {
-    expect(() => {
-      validateHostname("www.gov.uk");
-    }).toThrow();
-  });
-
-  test("throws an error when the hostname is the root account.gov.uk", () => {
-    expect(() => {
-      validateHostname("account.gov.uk");
-    }).toThrow();
-  });
-
-  test("throws an error when the hostname only contains localhost", () => {
-    expect(() => {
-      validateHostname("localhost.example.com");
-    }).toThrow();
   });
 });
 
 describe(handler, () => {
   beforeAll(() => {
     process.env.ENVIRONMENT = "test";
+    process.env.POST_LOGOUT_REDIRECT_URIS = JSON.stringify([
+      "https://home.dev.account.gov.uk/logout",
+      "https://home.dev.account.gov.uk/alternative-logout",
+    ]);
   });
 
   afterAll(() => {
     delete process.env.ENVIRONMENT;
-  });
-  test("returns a redirect response from a valid request with a referrer header", async () => {
-    const event: Partial<APIGatewayProxyEvent> = {
-      queryStringParameters: {
-        post_logout_redirect_uri: VALID_REDIRECT_OR_HEADER_URI,
-        id_token_hint: "id-token",
-      },
-      headers: {
-        Referer: VALID_REDIRECT_OR_HEADER_URI,
-      },
-    };
-    const response = await handler(event as APIGatewayProxyEvent);
-    expect(response.statusCode).toBe(302);
-    expect(response.headers.Location).toBe(VALID_REDIRECT_OR_HEADER_URI);
+    delete process.env.POST_LOGOUT_REDIRECT_URIS;
   });
 
-  test("returns a redirect response from a valid request with an origin header", async () => {
+  test("returns the default redirect URI when post_logout_redirect_uri is not a valid URI", async () => {
     const event: Partial<APIGatewayProxyEvent> = {
       queryStringParameters: {
-        post_logout_redirect_uri: VALID_REDIRECT_OR_HEADER_URI,
-        id_token_hint: "id-token",
-      },
-      headers: {
-        Origin: VALID_REDIRECT_OR_HEADER_URI,
-      },
-    };
-    const response = await handler(event as APIGatewayProxyEvent);
-    expect(response.statusCode).toBe(302);
-    expect(response.headers.Location).toBe(VALID_REDIRECT_OR_HEADER_URI);
-  });
-
-  test("returns a redirect response when neither redirect URI nor ID token are passed", async () => {
-    const event: Partial<APIGatewayProxyEvent> = {
-      headers: {
-        Origin: VALID_REDIRECT_OR_HEADER_URI,
-      },
-    };
-    const response = await handler(event as APIGatewayProxyEvent);
-    expect(response.statusCode).toBe(302);
-    expect(response.headers.Location).toBe(EXPECTED_INFERRED_REDIRECT_URI);
-  });
-
-  test("appends the state parameter to the redirect URL if provided", async () => {
-    const event: Partial<APIGatewayProxyEvent> = {
-      queryStringParameters: {
-        state: "stateValue",
-      },
-      headers: {
-        Origin: VALID_REDIRECT_OR_HEADER_URI,
+        post_logout_redirect_uri: "Not a URI",
+        id_token_hint: "123456789",
       },
     };
     const response = await handler(event as APIGatewayProxyEvent);
     expect(response.statusCode).toBe(302);
     expect(response.headers.Location).toBe(
-      `${EXPECTED_INFERRED_REDIRECT_URI}?state=stateValue`
+      "https://signin.test.account.gov.uk/signed-out"
     );
   });
 
-  test("throws an error when redirect URI is passed but not ID token", async () => {
+  test("returns the default redirect URI when id_token_hint is not sent", async () => {
     const event: Partial<APIGatewayProxyEvent> = {
       queryStringParameters: {
-        post_logout_redirect_uri: VALID_REDIRECT_OR_HEADER_URI,
-      },
-      headers: {
-        Referer: VALID_REDIRECT_OR_HEADER_URI,
+        post_logout_redirect_uri:
+          "https://home.dev.account.gov.uk/alternative-logout",
       },
     };
-    expect(handler(event as APIGatewayProxyEvent)).rejects.toThrow();
+    const response = await handler(event as APIGatewayProxyEvent);
+    expect(response.statusCode).toBe(302);
+    expect(response.headers.Location).toBe(
+      "https://signin.test.account.gov.uk/signed-out"
+    );
   });
 
-  test("throws an error when ID token is passed but not redirect URI", async () => {
+  test("returns the default redirect URI when post_logout_redirect_uri does not match the post logout URIs configured for the RP", async () => {
     const event: Partial<APIGatewayProxyEvent> = {
       queryStringParameters: {
-        id_token_hint: "id-token",
-      },
-      headers: {
-        Referer: VALID_REDIRECT_OR_HEADER_URI,
+        post_logout_redirect_uri:
+          "https://home.dev.account.gov.uk/unknown-logout",
+        id_token_hint: "123456789",
       },
     };
-    expect(handler(event as APIGatewayProxyEvent)).rejects.toThrow();
+    const response = await handler(event as APIGatewayProxyEvent);
+    expect(response.statusCode).toBe(302);
+    expect(response.headers.Location).toBe(
+      "https://signin.test.account.gov.uk/signed-out"
+    );
   });
 
-  test("throws an error when redirect URI is not on the allow list", async () => {
+  test("returns the sent redirect URI", async () => {
     const event: Partial<APIGatewayProxyEvent> = {
       queryStringParameters: {
-        post_logout_redirect_uri: "https://example.com/logout",
-        id_token_hint: "id-token",
-      },
-      headers: {
-        Referer: VALID_REDIRECT_OR_HEADER_URI,
+        post_logout_redirect_uri:
+          "https://home.dev.account.gov.uk/alternative-logout",
+        id_token_hint: "123456789",
       },
     };
-    expect(handler(event as APIGatewayProxyEvent)).rejects.toThrow();
+    const response = await handler(event as APIGatewayProxyEvent);
+    expect(response.statusCode).toBe(302);
+    expect(response.headers.Location).toBe(
+      "https://home.dev.account.gov.uk/alternative-logout"
+    );
   });
 
-  test("throws an error when referrer and origin headers are missing", async () => {
+  test("returns the sent redirect URI with state added to the query string", async () => {
     const event: Partial<APIGatewayProxyEvent> = {
       queryStringParameters: {
-        post_logout_redirect_uri: VALID_REDIRECT_OR_HEADER_URI,
-        id_token_hint: "id-token",
+        post_logout_redirect_uri:
+          "https://home.dev.account.gov.uk/alternative-logout",
+        id_token_hint: "123456789",
+        state: "fake_state",
       },
     };
-    expect(handler(event as APIGatewayProxyEvent)).rejects.toThrow();
-  });
-
-  test("throws an error when referrer is not on the allow list", async () => {
-    const event: Partial<APIGatewayProxyEvent> = {
-      queryStringParameters: {
-        post_logout_redirect_uri: VALID_REDIRECT_OR_HEADER_URI,
-        id_token_hint: "id-token",
-      },
-      headers: {
-        Referer: "https://example.com/logout",
-      },
-    };
-    expect(handler(event as APIGatewayProxyEvent)).rejects.toThrow();
-  });
-
-  test("throws an error when origin is not on the allow list", async () => {
-    const event: Partial<APIGatewayProxyEvent> = {
-      queryStringParameters: {
-        post_logout_redirect_uri: VALID_REDIRECT_OR_HEADER_URI,
-        id_token_hint: "id-token",
-      },
-      headers: {
-        Origin: "https://example.com/logout",
-      },
-    };
-    expect(handler(event as APIGatewayProxyEvent)).rejects.toThrow();
-  });
-
-  test("throws an error when referrer and redirect domains don't match", async () => {
-    const event: Partial<APIGatewayProxyEvent> = {
-      queryStringParameters: {
-        post_logout_redirect_uri: VALID_REDIRECT_OR_HEADER_URI,
-        id_token_hint: "id-token",
-      },
-      headers: {
-        Referer: "http://localhost/logout",
-      },
-    };
-    expect(handler(event as APIGatewayProxyEvent)).rejects.toThrow();
-  });
-
-  test("throws an error when origin and redirect domains don't match", async () => {
-    const event: Partial<APIGatewayProxyEvent> = {
-      queryStringParameters: {
-        post_logout_redirect_uri: VALID_REDIRECT_OR_HEADER_URI,
-        id_token_hint: "id-token",
-      },
-      headers: {
-        Origin: "http://localhost/logout",
-      },
-    };
-    expect(handler(event as APIGatewayProxyEvent)).rejects.toThrow();
+    const response = await handler(event as APIGatewayProxyEvent);
+    expect(response.statusCode).toBe(302);
+    expect(response.headers.Location).toBe(
+      "https://home.dev.account.gov.uk/alternative-logout?state=fake_state"
+    );
   });
 });

--- a/template.yaml
+++ b/template.yaml
@@ -40,6 +40,19 @@ Mappings:
       url: "https://home.build.account.gov.uk"
     demo:
       url: "https://home.demo.account.gov.uk"
+  PostLogoutRedirectUris:
+    dev:
+      uris:
+        Fn::ToJsonString:
+          - "https://home.dev.account.gov.uk/logout-return"
+    build:
+      uris:
+        Fn::ToJsonString:
+          - "https://home.build.account.gov.uk/logout-return"
+    demo:
+      uris:
+        Fn::ToJsonString:
+          - "https://home.demo.account.gov.uk/logout-return"
   TxmaDummyInputQueue:
     demo:
       QueueArn: "arn:aws:sqs:eu-west-2:654654326096:home-backend-TxMAInputDummyQueue-aydSI6PG6u3g"
@@ -908,6 +921,8 @@ Resources:
       Environment:
         Variables:
           ENVIRONMENT: !Ref Environment
+          POST_LOGOUT_REDIRECT_URIS:
+            !FindInMap [PostLogoutRedirectUris, !Ref Environment, uris]
       Events:
         logout:
           Type: Api

--- a/template.yaml
+++ b/template.yaml
@@ -1,5 +1,7 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Transform: AWS::Serverless-2016-10-31
+Transform:
+  - AWS::Serverless-2016-10-31
+  - AWS::LanguageExtensions
 Description: "A template to create the GOV.UK One login Account backend infrastructure."
 
 Parameters:

--- a/template.yaml
+++ b/template.yaml
@@ -1,7 +1,5 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Transform:
-  - AWS::Serverless-2016-10-31
-  - AWS::LanguageExtensions
+Transform: AWS::Serverless-2016-10-31
 Description: "A template to create the GOV.UK One login Account backend infrastructure."
 
 Parameters:
@@ -44,17 +42,11 @@ Mappings:
       url: "https://home.demo.account.gov.uk"
   PostLogoutRedirectUris:
     dev:
-      uris:
-        Fn::ToJsonString:
-          - "https://home.dev.account.gov.uk/logout-return"
+      uris: '["https://home.dev.account.gov.uk/logout-return"]'
     build:
-      uris:
-        Fn::ToJsonString:
-          - "https://home.build.account.gov.uk/logout-return"
+      uris: '["https://home.build.account.gov.uk/logout-return"]'
     demo:
-      uris:
-        Fn::ToJsonString:
-          - "https://home.demo.account.gov.uk/logout-return"
+      uris: '["https://home.demo.account.gov.uk/logout-return"]'
   TxmaDummyInputQueue:
     demo:
       QueueArn: "arn:aws:sqs:eu-west-2:654654326096:home-backend-TxMAInputDummyQueue-aydSI6PG6u3g"


### PR DESCRIPTION
### What changed

Changes the logout stub to better reflect what occurs in the real logout implementation. It now redirects the user to the sent `post_logout_redirect_uri` if it matches any of the URLs configured for the stub RP and `id_token_hint` is sent. Otherwise it redirects to the default URL `https://signin.{env}.account.gov.uk/signed-out`. If `state` is sent it is appended to the redirect URL when not redirecting to the default URL.

### Why did it change

So that the stub better reflects the real logout implementation.

### Related links

https://govukverify.atlassian.net/browse/OLH-2683

## Checklists

<!-- Merging this PR deploys the stubs. Please answer accurately. -->

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [x] Added parameters to Cloudformation template
- [ ] Added new secret or systems manager parameter
- [ ] Added new environment variable

### Permissions

- [ ] This PR adds or changes permissions