### PR TITLE
OLH-2683: Update logout redirect URLs

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -42,11 +42,11 @@ Mappings:
       url: "https://home.demo.account.gov.uk"
   PostLogoutRedirectUris:
     dev:
-      uris: '["https://home.dev.account.gov.uk/logout-return"]'
+      uris: '["http://localhost:6001/logout-redirect", "https://home.dev.account.gov.uk/logout-redirect"]'
     build:
-      uris: '["https://home.build.account.gov.uk/logout-return"]'
+      uris: '["https://home.build.account.gov.uk/logout-redirect"]'
     demo:
-      uris: '["https://home.demo.account.gov.uk/logout-return"]'
+      uris: '["https://home.demo.account.gov.uk/logout-redirect"]'
   TxmaDummyInputQueue:
     demo:
       QueueArn: "arn:aws:sqs:eu-west-2:654654326096:home-backend-TxMAInputDummyQueue-aydSI6PG6u3g"


### PR DESCRIPTION
### What changed

- Correct logout redirect URLs from `/logout-return` to `/logout-redirect`
- Support localhost redirect URL in dev

### Related links

https://govukverify.atlassian.net/browse/OLH-2683

## Checklists

<!-- Merging this PR deploys the stubs. Please answer accurately. -->

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [x] Added parameters to Cloudformation template
- [ ] Added new secret or systems manager parameter
- [ ] Added new environment variable
