### PR TITLE
[OLH-2627] Permanently suspended user should return code 1084

### DIFF
--- a/src/scenarios/scenarios.ts
+++ b/src/scenarios/scenarios.ts
@@ -487,8 +487,8 @@ export const userScenarios: UserScenarios = {
       success: true,
     },
     interventions: {
-      suspended: true,
-      blocked: false,
+      suspended: false,
+      blocked: true,
     },
   },
   temporarilySuspended: {


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->
[OLH-2627] Permanently suspended user should return code 1084

### What changed
<!-- Describe the changes in detail - the "what"-->
Switched scenario to blocked true

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
This user should return code 1084 but it is returning the same as the temp suspended user.

[OLH-2627]: https://govukverify.atlassian.net/browse/OLH-2627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ