### PR TITLE
Revert "OLH-2819: support HTTPS localhost"

### DIFF
--- a/src/oidc/validate-token.ts
+++ b/src/oidc/validate-token.ts
@@ -3,7 +3,6 @@ import { decodeJwt } from "jose";
 const SUPPORTED_REDIRECT_URLS = [
   "https%3A%2F%2Fhome.dev.account.gov.uk%2Fauth%2Fcallback",
   "http%3A%2F%2Flocalhost%3A6001%2Fauth%2Fcallback",
-  "https%3A%2F%2Flocalhost%3A6001%2Fauth%2Fcallback",
   "https%3A%2F%2Fhome.build.account.gov.uk%2Fauth%2Fcallback",
 ];
 const ALLOWED_GRANT_TYPES = ["authorization_code"];

--- a/src/tests/oidc/validate-token.test.ts
+++ b/src/tests/oidc/validate-token.test.ts
@@ -56,17 +56,9 @@ describe("validation for token", () => {
     ).not.toThrow("Invalid grant - Invalid redirect URL");
   });
 
-  test("should ensure http localhost redirect url works", async () => {
+  test("should ensure localhost redirect url works", async () => {
     const withInvalidRedirectUrl =
       "&client_assertion=xxxx&grant_type=authorization_code&code=xxxx&redirect_uri=http%3A%2F%2Flocalhost%3A6001%2Fauth%2Fcallback";
-    expect(() =>
-      validateRedirectURLSupported(withInvalidRedirectUrl)
-    ).not.toThrow("Invalid grant - Invalid redirect URL");
-  });
-
-  test("should ensure https localhost redirect url works", async () => {
-    const withInvalidRedirectUrl =
-      "&client_assertion=xxxx&grant_type=authorization_code&code=xxxx&redirect_uri=https%3A%2F%2Flocalhost%3A6001%2Fauth%2Fcallback";
     expect(() =>
       validateRedirectURLSupported(withInvalidRedirectUrl)
     ).not.toThrow("Invalid grant - Invalid redirect URL");

--- a/template.yaml
+++ b/template.yaml
@@ -42,7 +42,7 @@ Mappings:
       url: "https://home.demo.account.gov.uk"
   PostLogoutRedirectUris:
     dev:
-      uris: '["http://localhost:6001/logout-redirect", "https://localhost:6001/logout-redirect", "https://home.dev.account.gov.uk/logout-redirect"]'
+      uris: '["http://localhost:6001/logout-redirect", "https://home.dev.account.gov.uk/logout-redirect"]'
     build:
       uris: '["https://home.build.account.gov.uk/logout-redirect"]'
     demo:


### PR DESCRIPTION
Reverts govuk-one-login/account-management-stubs#505

These changes are no longer needed as the frontend won't use SSL when running locally.