### PR TITLE
Validate phone number and OTP code when creating SMS MFA method

### DIFF
--- a/src/method-management/method-management.ts
+++ b/src/method-management/method-management.ts
@@ -77,7 +77,11 @@ export const createMfaMethodHandler = async (
 ): Promise<APIGatewayProxyResult> => {
   const {
     priorityIdentifier = undefined,
-    method: { mfaMethodType = undefined } = {},
+    method: {
+      mfaMethodType = undefined,
+      phoneNumber = undefined,
+      otp = undefined,
+    } = {},
   } = JSON.parse(event.body || "{}").mfaMethod ?? {};
 
   const publicSubjectId = event.pathParameters?.publicSubjectId || "default";
@@ -99,6 +103,19 @@ export const createMfaMethodHandler = async (
         mfaMethodType: /^(AUTH_APP|SMS)$/,
       }
     );
+
+    if (mfaMethodType === "SMS") {
+      assert.notEqual(
+        typeof phoneNumber,
+        "undefined",
+        "Phone number is undefined"
+      );
+      assert.notEqual(typeof otp, "undefined", "OTP is undefined");
+      assert.notEqual(phoneNumber, null, "Phone number is null");
+      assert.notEqual(otp, null, "OTP is null");
+      assert.notEqual(phoneNumber.trim(), "", "Phone number is empty");
+      assert.notEqual(otp.trim(), "", "OTP is empty");
+    }
   } catch (e) {
     return formatResponse(400, { error: (e as Error).message });
   }

--- a/src/tests/method-management/method-management.test.ts
+++ b/src/tests/method-management/method-management.test.ts
@@ -201,6 +201,7 @@ describe("createMfaMethodHandler", () => {
         method: {
           mfaMethodType: "SMS",
           phoneNumber: "07123456789",
+          otp: "987654",
         },
       },
     };


### PR DESCRIPTION
### What changed

Validates the phone number and OTP code when creating an SMS MFA method

### Why did it change

To ensure that the parameters sent in the request align with what is expected in the real world