### PR TITLE
OLH-3085: Added Regional Policy tags to stub APIs for dev only

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -73,6 +73,7 @@ Conditions:
       - Fn::Equals:
           - !Ref PermissionsBoundary
           - "none"
+  IsDev: !Equals [!Ref Environment, dev]
 
 Globals:
   Function:
@@ -260,8 +261,8 @@ Resources:
         - ":"
         - [!GetAtt AccountManagementStubFunction.Arn, "live"]
       Tags:
-        FMSRegionalPolicy: false
-        CustomPolicy: true
+        FMSRegionalPolicy: !If [IsDev, false, ""]
+        CustomPolicy: !If [IsDev, true, ""]
 
   AccountManagementStubApiPermission:
     Type: AWS::Lambda::Permission
@@ -426,8 +427,8 @@ Resources:
       AccessLogSetting:
         DestinationArn: !GetAtt ApiGatewayApiLogGroup.Arn
       Tags:
-        FMSRegionalPolicy: false
-        CustomPolicy: true
+        FMSRegionalPolicy: !If [IsDev, false, ""]
+        CustomPolicy: !If [IsDev, true, ""]
 
   ApiGatewayApiLogGroup:
     Type: AWS::Logs::LogGroup
@@ -1002,8 +1003,8 @@ Resources:
       AccessLogSetting:
         DestinationArn: !GetAtt MethodManagementv1ApiGatewayApiLogGroup.Arn
       Tags:
-        FMSRegionalPolicy: false
-        CustomPolicy: true
+        FMSRegionalPolicy: !If [IsDev, false, ""]
+        CustomPolicy: !If [IsDev, true, ""]
 
   MethodManagementv1ApiGatewayApiLogGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
## Proposed changes

Add tags to stubs APIs so that they FMS WAFs get associated with custom WAF in dev env only.

### What changed
API Resources have new tags with propagation to stages

### Why did it change
Confirm with GDS non-prod WAF policy managed by FMS

### Related links
https://github.com/govuk-one-login/account-management-stubs/pull/532
https://github.com/govuk-one-login/account-management-stubs/pull/531

## Checklists

<!-- Merging this PR deploys the stubs. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Added parameters to Cloudformation template
- [ ] Added new secret or systems manager parameter
- [ ] Added new environment variable

### Permissions

- [ ] This PR adds or changes permissions

## Testing
Deployed to dev using both `dev` and `build` environment parameter to check conditions work as expected

## How to review

<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
