### PR TITLE
OLH-3699 remove cookie check in AMC stub

### DIFF
--- a/src/amc/amc-routes.ts
+++ b/src/amc/amc-routes.ts
@@ -27,16 +27,6 @@ export const handler = async (event: APIGatewayProxyEvent) => {
     const params = event.queryStringParameters || {};
     const errors: string[] = [];
 
-    const cookies = event.headers?.Cookie || event.headers?.cookie || "";
-    const amcCookie = cookies
-      .split(";")
-      .map((c) => c.trim())
-      .find((c) => c.startsWith("amc="));
-    const amcValue = amcCookie?.split("=").slice(1).join("=") || "";
-    if (amcValue.length === 0) {
-      errors.push("amc cookie is required and must not be empty");
-    }
-
     if (!params.client_id || params.client_id.length === 0) {
       errors.push("client_id is required and must not be empty");
     }


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

Remove the cookie check in the AMC auth stub

### Why did it change

It is incompatiable with running locally or on test environemnts as we can't set cookies cross domain.

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR deploys the stubs. Please answer accurately. -->

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Added parameters to Cloudformation template
- [ ] Added new secret or systems manager parameter
- [ ] Added new environment variable

### Permissions

- [ ] This PR adds or changes permissions

## Testing

<!-- Provide a summary of any manual testing you've done, for example, deploying the branch to dev -->

## How to review

<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
