### PR TITLE
OLH-4070: fix GET passkeys response shape

### DIFF
--- a/src/method-management/method-management.ts
+++ b/src/method-management/method-management.ts
@@ -243,7 +243,7 @@ export const getPasskeysHandler = async (
 
   const passkeys = getUserScenario(publicSubjectId, "passkeys");
 
-  return formatResponse(200, passkeys);
+  return formatResponse(200, { passkeys });
 };
 
 export const deletePasskeyHandler = async (

--- a/src/tests/method-management/method-management.test.ts
+++ b/src/tests/method-management/method-management.test.ts
@@ -685,12 +685,14 @@ describe("getPasskeysHandler", () => {
     const fakeEvent = createFakeAPIGatewayProxyEvent("withPasskeys");
     const response = await getPasskeysHandler(fakeEvent);
     expect(response.statusCode).toBe(200);
-    expect(JSON.parse(response.body)).toStrictEqual([
-      {
-        credentialId: "cred123",
-        friendlyName: "My Passkey",
-      },
-    ]);
+    expect(JSON.parse(response.body)).toStrictEqual({
+      passkeys: [
+        {
+          credentialId: "cred123",
+          friendlyName: "My Passkey",
+        },
+      ],
+    });
   });
 
   test("should return 403 when Authorization header is missing", async () => {


### PR DESCRIPTION
Fixes the GET passkeys handler to return `{ passkeys: [...] }` rather than just a bare array. This makes it match the API spec.