### PR TITLE
BAU: group GitHub Actions dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,6 +45,11 @@ updates:
       - dependencies
     commit-message:
       prefix: BAU
+    groups:
+      github-actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "pre-commit"
     directories:


### PR DESCRIPTION
Group minor and patch version updates for GitHub Actions into a single PR to reduce noise. Major version bumps remain as separate PRs.