### PR TITLE
BAU: add dependabot dependency grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -87,3 +87,8 @@ updates:
     labels:
       - dependabot
       - dependencies
+    groups:
+      pip-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -66,6 +66,11 @@ updates:
       - dependencies
     commit-message:
       prefix: BAU
+    groups:
+      pre-commit-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: pip
     directories:


### PR DESCRIPTION
Add minor/patch grouping to dependabot ecosystems that were previously ungrouped, reducing the number of individual PRs created per cycle.

Groups added:
- pip: `pip-minor-patch`
- pre-commit: `pre-commit-minor-patch`

Major version bumps are excluded from all groups and will continue to get individual PRs as they are more likely to contain breaking changes.