### PR TITLE
OLH-4233: Bump amc stub lambda timeout to 10

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1529,7 +1529,7 @@ Resources:
       MemorySize: 128
       ReservedConcurrentExecutions: 30
       Role: !GetAtt AmcLambdaRole.Arn
-      Timeout: 5
+      Timeout: 10
       Events:
         CatchAll:
           Type: Api


### PR DESCRIPTION
Some integration tests, including the "add passkey" one which relies on this lambda, have been failing intermittently in Github Actions. The point of failure seems to be the call to get AMC JWKS.

After some investigation, this seemed to be happening due to the lambda reaching its internal timeout limit and being forcefully terminated. Increasing the limit should allow the lambda more breathing room to complete computationally expensive key generation on cold start.

This handler deals with more than just requests the `/.well-known/jwks.json ` endpoint so as far as I understand it, we're technically increasing the internal timeout on all of them. 
Keen to hear thoughts on any potential consequences/implications.